### PR TITLE
SLING-3524: Allow distinguishing cloning from normal login in providers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.18.0</version>
+            <version>2.18.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryImpl.java
@@ -63,17 +63,9 @@ public class ResourceResolverFactoryImpl implements ResourceResolverFactory {
      */
     @Override
     public ResourceResolver getServiceResourceResolver(final Map<String, Object> passedAuthenticationInfo) throws LoginException {
-        // create a copy of the passed authentication info as we modify the map
-        final Map<String, Object> authenticationInfo = new HashMap<>();
-        final String subServiceName;
-        if ( passedAuthenticationInfo != null ) {
-            authenticationInfo.putAll(passedAuthenticationInfo);
-            authenticationInfo.remove(PASSWORD);
-            final Object info = passedAuthenticationInfo.get(SUBSERVICE);
-            subServiceName = (info instanceof String) ? (String) info : null;
-        } else {
-            subServiceName = null;
-        }
+        final Map<String, Object> authenticationInfo = CommonResourceResolverFactoryImpl.sanitizeAuthenticationInfo(passedAuthenticationInfo, PASSWORD);
+        final Object info = authenticationInfo.get(SUBSERVICE);
+        final String subServiceName = (info instanceof String) ? (String) info : null;
 
         // Ensure a mapped user or principal name(s): If no user/principal names is/are
         // defined for a bundle acting as a service, the user may be null. We can decide whether

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -59,6 +59,7 @@ import org.apache.sling.resourceresolver.impl.helper.URIException;
 import org.apache.sling.resourceresolver.impl.mapping.MapEntry;
 import org.apache.sling.resourceresolver.impl.params.ParsedParameters;
 import org.apache.sling.resourceresolver.impl.providers.ResourceProviderStorageProvider;
+import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,6 +118,7 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         if (authenticationInfo != null) {
             authInfo.putAll(authenticationInfo);
         }
+        authInfo.put(ResourceProvider.AUTH_CLONE, true);
         this.context = new ResourceResolverContext(this, factory.getResourceAccessSecurityTracker());
         this.control = createControl(factory.getResourceProviderTracker(), authInfo, resolver.control.isAdmin());
         this.factory.register(this, control);


### PR DESCRIPTION
This is the other half of the API changes necessary for fixing SLING-3524. There are two related pull requests to implement a full fix. To avoid repeating myself, I'll update the corresponding JIRA ticket with the reasoning, and with the links of the other requests.