### PR TITLE
SLING-8335 :StringIndexOutOfBoundsException from resolver.map with no…

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -689,6 +689,10 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
      */
     public Resource resolveInternal(final String absPath, final Map<String, String> parameters) {
         Resource resource = null;
+        if (absPath != null && !absPath.startsWith("/")) {
+            logger.debug("resolveInternal: absolute path expected {} ",absPath);
+            return resource; // resource is null at this point
+        }
         String curPath = absPath;
         try {
             final ResourcePathIterator it = new ResourcePathIterator(absPath);

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -553,6 +553,8 @@ public class MockedResourceResolverImplTest {
         path = resourceResolver.map("/content.html");
         Assert.assertEquals("/content.html", path);
 
+        path = resourceResolver.map(request,"some/relative/path/test");
+        Assert.assertEquals("some/relative/path/test", path);
     }
 
 


### PR DESCRIPTION
…n absolute path

check for absolute path at the beginning of the method