### PR TITLE
SLING-8341 : find extra slashes and ignore redundant delimiteres

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
@@ -731,6 +732,9 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
 
             final StringBuilder resolutionPath = new StringBuilder();
             final StringTokenizer tokener = new StringTokenizer(tokenizedPath, "/");
+            final int delimCount = StringUtils.countMatches(tokenizedPath,'/');
+            final int redundantDelimCount = delimCount - tokener.countTokens();
+
             while (resource != null && tokener.hasMoreTokens()) {
                 final String childNameRaw = tokener.nextToken();
 
@@ -767,7 +771,7 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
             // uriPath = curPath + sling.resolutionPathInfo
             if (resource != null) {
                 final String path = resolutionPath.toString();
-                final String pathInfo = absPath.substring(path.length());
+                final String pathInfo = absPath.substring(path.length() + redundantDelimCount);
 
                 resource.getResourceMetadata().setResolutionPath(path);
                 resource.getResourceMetadata().setResolutionPathInfo(pathInfo);

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -150,7 +150,7 @@ public class MockedResourceResolverImplTest {
         activator.resourceProviderTracker = resourceProviderTracker;
         activator.changeListenerWhiteboard = resourceChangeListenerWhiteboard;
         activator.serviceUserMapper = Mockito.mock(ServiceUserMapper.class);
-        handlers.add(createRPHandler(resourceProvider, "org.apache.sling.resourceresolver.impl.DummyTestProvider", 10L, "/single"));
+        handlers.add(createRPHandler(resourceProvider, "org.apache.sling.resourceresolver.impl.DummyTestProvider", 10L, "/"));
 
         // setup mapping resources at /etc/map to exercise vanity etc.
         // hmm, can't provide the resolver since its not up and ready.
@@ -553,6 +553,11 @@ public class MockedResourceResolverImplTest {
         path = resourceResolver.map("/content.html");
         Assert.assertEquals("/content.html", path);
 
+        buildResource("/", EMPTY_RESOURCE_LIST, resourceResolver, resourceProvider);
+        buildResource("/single", EMPTY_RESOURCE_LIST, resourceResolver, resourceProvider);
+        buildResource("/single/test", EMPTY_RESOURCE_LIST, resourceResolver, resourceProvider);
+        path = resourceResolver.map("/single//test.html");
+        Assert.assertEquals("/single/test.html", path);
     }
 
 


### PR DESCRIPTION
find the difference of the redundant occurrences vs actual tokens of delimiter ( slash '/ ')