### PR TITLE
SLING-8349 : resolver.map - map empty path to root path

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -690,7 +690,7 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
      */
     public Resource resolveInternal(final String absPath, final Map<String, String> parameters) {
         Resource resource = null;
-        if (absPath != null && !absPath.startsWith("/")) {
+        if (absPath != null && !absPath.isEmpty() && !absPath.startsWith("/")) {
             logger.debug("resolveInternal: absolute path expected {} ",absPath);
             return resource; // resource is null at this point
         }


### PR DESCRIPTION
empty path should map to root instead of a null resource. 