### PR TITLE
SLING-10431 - ResourceMapperImpl tests no longer running with optimised alias resolution

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -1058,7 +1058,7 @@ public class MapEntries implements
             baseQuery.append(")");
         }
 
-        baseQuery.append(" AND sling:alias IS NOT NULL ");
+        baseQuery.append(" AND sling:alias IS NOT NULL");
         String aliasQuery = baseQuery.toString();
         logger.debug("Query to fetch alias [{}] ", aliasQuery);
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/InMemoryResourceProvider.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/InMemoryResourceProvider.java
@@ -97,7 +97,9 @@ public class InMemoryResourceProvider extends ResourceProvider<Void>{
             @Override
             public Iterator<Resource> findResources(@NotNull ResolveContext<Void> ctx, String query, String language) {
                 
-                if  ( "SELECT sling:alias FROM nt:base WHERE sling:alias IS NOT NULL".equals(query) ) {
+                // we don't explicitly filter paths under jcr:system, but we don't expect to have such resources either
+                // and this stub provider is not the proper location to test JCR queries
+                if  ( "SELECT sling:alias FROM nt:base AS page WHERE (NOT ISDESCENDANTNODE(page,\"/jcr:system\")) AND sling:alias IS NOT NULL".equals(query) ) {
                     return resourcesWithProperty(ctx, "sling:alias")
                         .iterator();
                 }


### PR DESCRIPTION
Adapt to the new query and also make it slightly nicer by default by removing a trailing whitespace.