### PR TITLE
SLING-10844: ResourceMapper.getMapping() returns null for empty path

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -154,7 +154,7 @@ public class ResourceMapperImpl implements ResourceMapper {
         }
 
         // 5. add the requested path itself, if not already populated
-        if (!mappings.contains(mappedPath))
+        if ( !mappedPath.isEmpty() && !mappings.contains(mappedPath))
             mappings.add(0, mappedPath);
         
         // 6. add vanity paths

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -72,7 +72,7 @@ public class ResourceMapperImpl implements ResourceMapper {
         
         Collection<String> mappings = getAllMappings(resourcePath, request);
         if ( mappings.isEmpty() )
-            return null;
+            return "";
         
         return mappings.iterator().next();
     }
@@ -154,7 +154,7 @@ public class ResourceMapperImpl implements ResourceMapper {
         }
 
         // 5. add the requested path itself, if not already populated
-        if ( !mappedPath.isEmpty() && !mappings.contains(mappedPath))
+        if (!mappings.contains(mappedPath))
             mappings.add(0, mappedPath);
         
         // 6. add vanity paths

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -105,7 +105,7 @@ public class ResourceMapperImplTest {
 
         InMemoryResourceProvider resourceProvider = new InMemoryResourceProvider();
 
-        if(!testName.getMethodName().contains("mapEmptyPathWithNonExistingResource")) {
+        if(!testName.getMethodName().contains("mapEmptyPathWithUnreadableRoot")) {
             resourceProvider.putResource("/"); // root
         }
         resourceProvider.putResource("/here"); // regular page
@@ -165,11 +165,11 @@ public class ResourceMapperImplTest {
     public void mapNonExistingEmptyPath() throws LoginException {
 
         ExpectedMappings.nonExistingResource("")
-                .singleMapping("/")
-                .singleMappingWithRequest("/app/")
-                .allMappings("/")
-                .allMappingsWithRequest("/app/")
-                .verify(resolver, req);
+            .singleMapping("/")
+            .singleMappingWithRequest("/app/")
+            .allMappings("/")
+            .allMappingsWithRequest("/app/")
+            .verify(resolver, req);
     }
 
     /**
@@ -181,11 +181,11 @@ public class ResourceMapperImplTest {
     public void mapNonExistingPath() throws LoginException {
 
         ExpectedMappings.nonExistingResource("/not-here")
-                .singleMapping("/not-here")
-                .singleMappingWithRequest("/app/not-here")
-                .allMappings("/not-here")
-                .allMappingsWithRequest("/app/not-here")
-                .verify(resolver, req);
+            .singleMapping("/not-here")
+            .singleMappingWithRequest("/app/not-here")
+            .allMappings("/not-here")
+            .allMappingsWithRequest("/app/not-here")
+            .verify(resolver, req);
     }
 
     /**
@@ -197,11 +197,11 @@ public class ResourceMapperImplTest {
     public void mapExistingPath() throws LoginException {
 
         ExpectedMappings.existingResource("/here")
-                .singleMapping("/here")
-                .singleMappingWithRequest("/app/here")
-                .allMappings("/here")
-                .allMappingsWithRequest("/app/here")
-                .verify(resolver, req);
+            .singleMapping("/here")
+            .singleMappingWithRequest("/app/here")
+            .allMappings("/here")
+            .allMappingsWithRequest("/app/here")
+            .verify(resolver, req);
     }
 
     /**
@@ -229,11 +229,11 @@ public class ResourceMapperImplTest {
     public void mapResourceWithMultivaluedAlias() {
 
         ExpectedMappings.existingResource("/there-multiple")
-                .singleMapping("/alias-value-3")
-                .singleMappingWithRequest("/app/alias-value-3")
-                .allMappings("/alias-value-3", "/alias-value-4", "/there-multiple")
-                .allMappingsWithRequest("/app/alias-value-3", "/app/alias-value-4", "/app/there-multiple")
-                .verify(resolver, req);
+            .singleMapping("/alias-value-3")
+            .singleMappingWithRequest("/app/alias-value-3")
+            .allMappings("/alias-value-3", "/alias-value-4", "/there-multiple")
+            .allMappingsWithRequest("/app/alias-value-3", "/app/alias-value-4", "/app/there-multiple")
+            .verify(resolver, req);
     }
 
     /**
@@ -262,11 +262,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapResourceWithAliasOnParent() {
         ExpectedMappings.existingResource("/there/that")
-                .singleMapping("/alias-value/that")
-                .singleMappingWithRequest("/app/alias-value/that")
-                .allMappings("/alias-value/that", "/there/that")
-                .allMappingsWithRequest("/app/alias-value/that","/app/there/that")
-                .verify(resolver, req);
+            .singleMapping("/alias-value/that")
+            .singleMappingWithRequest("/app/alias-value/that")
+            .allMappings("/alias-value/that", "/there/that")
+            .allMappingsWithRequest("/app/alias-value/that","/app/there/that")
+            .verify(resolver, req);
     }
 
     @Test
@@ -280,11 +280,11 @@ public class ResourceMapperImplTest {
         when(req.getPathInfo()).thenReturn(null);
 
         ExpectedMappings.existingResource("/content/virtual/foo")
-                .singleMapping("http://virtual.host.com/foo")
-                .singleMappingWithRequest("/foo")
-                .allMappings("http://virtual.host.com/foo", "/content/virtual/foo")
-                .allMappingsWithRequest("/foo", "/content/virtual/foo")
-                .verify(resolver, req);
+            .singleMapping("http://virtual.host.com/foo")
+            .singleMappingWithRequest("/foo")
+            .allMappings("http://virtual.host.com/foo", "/content/virtual/foo")
+            .allMappingsWithRequest("/foo", "/content/virtual/foo")
+            .verify(resolver, req);
 
     }
 
@@ -297,11 +297,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapResourceWithNestedAlias() {
         ExpectedMappings.existingResource("/parent/child")
-                .singleMapping("/alias-parent/alias-child")
-                .singleMappingWithRequest("/app/alias-parent/alias-child")
-                .allMappings("/alias-parent/alias-child", "/alias-parent/child", "/parent/alias-child", "/parent/child")
-                .allMappingsWithRequest("/app/alias-parent/alias-child", "/app/alias-parent/child", "/app/parent/alias-child", "/app/parent/child")
-                .verify(resolver, req);
+            .singleMapping("/alias-parent/alias-child")
+            .singleMappingWithRequest("/app/alias-parent/alias-child")
+            .allMappings("/alias-parent/alias-child", "/alias-parent/child", "/parent/alias-child", "/parent/child")
+            .allMappingsWithRequest("/app/alias-parent/alias-child", "/app/alias-parent/child", "/app/parent/alias-child", "/app/parent/child")
+            .verify(resolver, req);
     }
 
     /**
@@ -312,11 +312,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapResourceWithNestedMultipleAlias() {
         ExpectedMappings.existingResource("/parent/child-multiple")
-                .singleMapping("/alias-parent/alias-child-1")
-                .singleMappingWithRequest("/app/alias-parent/alias-child-1")
-                .allMappings("/alias-parent/alias-child-1", "/alias-parent/alias-child-2", "/alias-parent/child-multiple", "/parent/alias-child-1", "/parent/alias-child-2", "/parent/child-multiple")
-                .allMappingsWithRequest("/app/alias-parent/alias-child-1", "/app/alias-parent/alias-child-2", "/app/alias-parent/child-multiple", "/app/parent/alias-child-1", "/app/parent/alias-child-2", "/app/parent/child-multiple")
-                .verify(resolver, req);
+            .singleMapping("/alias-parent/alias-child-1")
+            .singleMappingWithRequest("/app/alias-parent/alias-child-1")
+            .allMappings("/alias-parent/alias-child-1", "/alias-parent/alias-child-2", "/alias-parent/child-multiple", "/parent/alias-child-1", "/parent/alias-child-2", "/parent/child-multiple")
+            .allMappingsWithRequest("/app/alias-parent/alias-child-1", "/app/alias-parent/alias-child-2", "/app/alias-parent/child-multiple", "/app/parent/alias-child-1", "/app/parent/alias-child-2", "/app/parent/child-multiple")
+            .verify(resolver, req);
     }
 
     /**
@@ -328,11 +328,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapResourceWithVanityPaths() {
         ExpectedMappings.existingResource("/vain")
-                .singleMapping("/vain")
-                .singleMappingWithRequest("/app/vain")
-                .allMappings("/vanity-a", "/vanity-b", "/vain")
-                .allMappingsWithRequest("/app/vanity-a", "/app/vanity-b", "/app/vain")
-                .verify(resolver, req);
+            .singleMapping("/vain")
+            .singleMappingWithRequest("/app/vain")
+            .allMappings("/vanity-a", "/vanity-b", "/vain")
+            .allMappingsWithRequest("/app/vanity-a", "/app/vanity-b", "/app/vain")
+            .verify(resolver, req);
     }
 
     /**
@@ -342,11 +342,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapAliasTarget() {
         ExpectedMappings.nonExistingResource("/alias-value")
-                .singleMapping("/alias-value")
-                .singleMappingWithRequest("/app/alias-value")
-                .allMappings("/alias-value")
-                .allMappingsWithRequest("/app/alias-value")
-                .verify(resolver, req);
+            .singleMapping("/alias-value")
+            .singleMappingWithRequest("/app/alias-value")
+            .allMappings("/alias-value")
+            .allMappingsWithRequest("/app/alias-value")
+            .verify(resolver, req);
     }
 
     /**
@@ -356,11 +356,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapNestedAliasTarget() {
         ExpectedMappings.nonExistingResource("/alias-parent/alias-child")
-                .singleMapping("/alias-parent/alias-child")
-                .singleMappingWithRequest("/app/alias-parent/alias-child")
-                .allMappings("/alias-parent/alias-child", "/alias-parent/child", "/parent/alias-child")
-                .allMappingsWithRequest("/app/alias-parent/alias-child", "/app/alias-parent/child", "/app/parent/alias-child")
-                .verify(resolver, req);
+            .singleMapping("/alias-parent/alias-child")
+            .singleMappingWithRequest("/app/alias-parent/alias-child")
+            .allMappings("/alias-parent/alias-child", "/alias-parent/child", "/parent/alias-child")
+            .allMappingsWithRequest("/app/alias-parent/alias-child", "/app/alias-parent/child", "/app/parent/alias-child")
+            .verify(resolver, req);
     }
 
     /**
@@ -369,15 +369,15 @@ public class ResourceMapperImplTest {
      * @throws LoginException
      */
     @Test
-    public void mapEmptyPathWithNonExistingResource() {
+    public void mapEmptyPathWithUnreadableRoot() {
         String [] expectedAllMappings = new String[0];
 
         ExpectedMappings.nonExistingResource("")
-                .singleMapping("")
-                .singleMappingWithRequest("")
-                .allMappings(expectedAllMappings)
-                .allMappingsWithRequest(expectedAllMappings)
-                .verify(resolver, req);
+            .singleMapping("")
+            .singleMappingWithRequest("")
+            .allMappings(expectedAllMappings)
+            .allMappingsWithRequest(expectedAllMappings)
+            .verify(resolver, req);
     }
 
     static class ExpectedMappings {

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,8 +42,6 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.mapping.ResourceMapper;
 import org.apache.sling.resourceresolver.impl.ResourceAccessSecurityTracker;
 import org.apache.sling.resourceresolver.impl.ResourceResolverFactoryActivator;
-import org.apache.sling.resourceresolver.impl.ResourceResolverImpl;
-import org.apache.sling.resourceresolver.impl.helper.ResourceDecoratorTracker;
 import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
 import org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
@@ -53,6 +50,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -85,7 +83,10 @@ public class ResourceMapperImplTest {
     }
 
     @Rule
-    public final OsgiContext ctx = new OsgiContext();
+    public OsgiContext ctx = new OsgiContext();
+
+    @Rule
+    public TestName testName = new TestName();
 
     private final boolean optimiseAliasResolution;
     private HttpServletRequest req;
@@ -103,7 +104,10 @@ public class ResourceMapperImplTest {
         ctx.registerInjectActivateService(new StringInterpolationProviderImpl());
 
         InMemoryResourceProvider resourceProvider = new InMemoryResourceProvider();
-        resourceProvider.putResource("/"); // root
+
+        if(!testName.getMethodName().contains("mapEmptyPathWithNonExistingResource")) {
+            resourceProvider.putResource("/"); // root
+        }
         resourceProvider.putResource("/here"); // regular page
         resourceProvider.putResource("/there", PROP_ALIAS, "alias-value"); // with alias
         resourceProvider.putResource("/there-multiple", PROP_ALIAS, "alias-value-3", "alias-value-4"); // with multivalued alias
@@ -161,11 +165,11 @@ public class ResourceMapperImplTest {
     public void mapNonExistingEmptyPath() throws LoginException {
 
         ExpectedMappings.nonExistingResource("")
-            .singleMapping("/")
-            .singleMappingWithRequest("/app/")
-            .allMappings("/")
-            .allMappingsWithRequest("/app/")
-            .verify(resolver, req);
+                .singleMapping("/")
+                .singleMappingWithRequest("/app/")
+                .allMappings("/")
+                .allMappingsWithRequest("/app/")
+                .verify(resolver, req);
     }
 
     /**
@@ -177,11 +181,11 @@ public class ResourceMapperImplTest {
     public void mapNonExistingPath() throws LoginException {
 
         ExpectedMappings.nonExistingResource("/not-here")
-            .singleMapping("/not-here")
-            .singleMappingWithRequest("/app/not-here")
-            .allMappings("/not-here")
-            .allMappingsWithRequest("/app/not-here")
-            .verify(resolver, req);
+                .singleMapping("/not-here")
+                .singleMappingWithRequest("/app/not-here")
+                .allMappings("/not-here")
+                .allMappingsWithRequest("/app/not-here")
+                .verify(resolver, req);
     }
 
     /**
@@ -193,11 +197,11 @@ public class ResourceMapperImplTest {
     public void mapExistingPath() throws LoginException {
 
         ExpectedMappings.existingResource("/here")
-            .singleMapping("/here")
-            .singleMappingWithRequest("/app/here")
-            .allMappings("/here")
-            .allMappingsWithRequest("/app/here")
-            .verify(resolver, req);
+                .singleMapping("/here")
+                .singleMappingWithRequest("/app/here")
+                .allMappings("/here")
+                .allMappingsWithRequest("/app/here")
+                .verify(resolver, req);
     }
 
     /**
@@ -209,11 +213,11 @@ public class ResourceMapperImplTest {
     public void mapResourceWithAlias() {
 
         ExpectedMappings.existingResource("/there")
-            .singleMapping("/alias-value")
-            .singleMappingWithRequest("/app/alias-value")
-            .allMappings("/alias-value", "/there")
-            .allMappingsWithRequest("/app/alias-value", "/app/there")
-            .verify(resolver, req);
+                .singleMapping("/alias-value")
+                .singleMappingWithRequest("/app/alias-value")
+                .allMappings("/alias-value", "/there")
+                .allMappingsWithRequest("/app/alias-value", "/app/there")
+                .verify(resolver, req);
     }
 
     /**
@@ -242,11 +246,11 @@ public class ResourceMapperImplTest {
     public void mapResourceWithAliasAndEtcMap() {
 
         ExpectedMappings.existingResource("/somewhere")
-            .singleMapping("/alias-value-2")
-            .singleMappingWithRequest("/app/alias-value-2")
-            .allMappings("/alias-value-2", "http://localhost:8080/everywhere", "/somewhere")
-            .allMappingsWithRequest("/app/alias-value-2", "/app/everywhere", "/app/somewhere")
-            .verify(resolver, req);
+                .singleMapping("/alias-value-2")
+                .singleMappingWithRequest("/app/alias-value-2")
+                .allMappings("/alias-value-2", "http://localhost:8080/everywhere", "/somewhere")
+                .allMappingsWithRequest("/app/alias-value-2", "/app/everywhere", "/app/somewhere")
+                .verify(resolver, req);
     }
 
     /**
@@ -258,11 +262,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapResourceWithAliasOnParent() {
         ExpectedMappings.existingResource("/there/that")
-            .singleMapping("/alias-value/that")
-            .singleMappingWithRequest("/app/alias-value/that")
-            .allMappings("/alias-value/that", "/there/that")
-            .allMappingsWithRequest("/app/alias-value/that","/app/there/that")
-            .verify(resolver, req);
+                .singleMapping("/alias-value/that")
+                .singleMappingWithRequest("/app/alias-value/that")
+                .allMappings("/alias-value/that", "/there/that")
+                .allMappingsWithRequest("/app/alias-value/that","/app/there/that")
+                .verify(resolver, req);
     }
 
     @Test
@@ -276,11 +280,11 @@ public class ResourceMapperImplTest {
         when(req.getPathInfo()).thenReturn(null);
 
         ExpectedMappings.existingResource("/content/virtual/foo")
-            .singleMapping("http://virtual.host.com/foo")
-            .singleMappingWithRequest("/foo")
-            .allMappings("http://virtual.host.com/foo", "/content/virtual/foo")
-            .allMappingsWithRequest("/foo", "/content/virtual/foo")
-            .verify(resolver, req);
+                .singleMapping("http://virtual.host.com/foo")
+                .singleMappingWithRequest("/foo")
+                .allMappings("http://virtual.host.com/foo", "/content/virtual/foo")
+                .allMappingsWithRequest("/foo", "/content/virtual/foo")
+                .verify(resolver, req);
 
     }
 
@@ -324,11 +328,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapResourceWithVanityPaths() {
         ExpectedMappings.existingResource("/vain")
-            .singleMapping("/vain")
-            .singleMappingWithRequest("/app/vain")
-            .allMappings("/vanity-a", "/vanity-b", "/vain")
-            .allMappingsWithRequest("/app/vanity-a", "/app/vanity-b", "/app/vain")
-            .verify(resolver, req);
+                .singleMapping("/vain")
+                .singleMappingWithRequest("/app/vain")
+                .allMappings("/vanity-a", "/vanity-b", "/vain")
+                .allMappingsWithRequest("/app/vanity-a", "/app/vanity-b", "/app/vain")
+                .verify(resolver, req);
     }
 
     /**
@@ -338,11 +342,11 @@ public class ResourceMapperImplTest {
     @Test
     public void mapAliasTarget() {
         ExpectedMappings.nonExistingResource("/alias-value")
-            .singleMapping("/alias-value")
-            .singleMappingWithRequest("/app/alias-value")
-            .allMappings("/alias-value")
-            .allMappingsWithRequest("/app/alias-value")
-            .verify(resolver, req);
+                .singleMapping("/alias-value")
+                .singleMappingWithRequest("/app/alias-value")
+                .allMappings("/alias-value")
+                .allMappingsWithRequest("/app/alias-value")
+                .verify(resolver, req);
     }
 
     /**
@@ -366,21 +370,13 @@ public class ResourceMapperImplTest {
      */
     @Test
     public void mapEmptyPathWithNonExistingResource() {
-        MapEntriesHandler mapEntriesHandler = mock(MapEntriesHandler.class);
-        when(mapEntriesHandler.getVanityPathMappings()).thenReturn(Collections.emptyMap());
-
-        ResourceResolverImpl resolver = mock(ResourceResolverImpl.class);
-        when(resolver.resolveInternal(any(), any())).thenReturn(null);
-        when(resolver.getResource("")).thenReturn(this.resolver.getResource(""));
-        when(resolver.adaptTo(ResourceMapper.class)).thenReturn(new ResourceMapperImpl(resolver, mock(ResourceDecoratorTracker.class),
-                mapEntriesHandler, mock(Object.class)));
+        String [] expectedAllMappings = new String[0];
 
         ExpectedMappings.nonExistingResource("")
                 .singleMapping("")
                 .singleMappingWithRequest("")
-                .allMappings("")
-                .allMappingsWithRequest("")
-                .testingEmptyPathWithNonExistingResource(true)
+                .allMappings(expectedAllMappings)
+                .allMappingsWithRequest(expectedAllMappings)
                 .verify(resolver, req);
     }
 
@@ -401,17 +397,10 @@ public class ResourceMapperImplTest {
         private String singleMappingWithRequest;
         private Set<String> allMappings;
         private Set<String> allMappingsWithRequest;
-        private boolean testingEmptyPathWithNonExistingResource = false;
 
         private ExpectedMappings(String path, boolean exists) {
             this.path = path;
             this.exists = exists;
-        }
-
-        public ExpectedMappings testingEmptyPathWithNonExistingResource(boolean testingEmptyPathWithNonExistingResource) {
-            this.testingEmptyPathWithNonExistingResource = testingEmptyPathWithNonExistingResource;
-
-            return this;
         }
 
         public ExpectedMappings singleMapping(String singleMapping) {
@@ -455,7 +444,6 @@ public class ResourceMapperImplTest {
             assertThat("Single mapping without request", mapper.getMapping(path), is(singleMapping));
             if ( !path.isEmpty() ) // an empty path is invalid, hence not testing with a request
                 assertThat("Single mapping with request", mapper.getMapping(path, request), is(singleMappingWithRequest));
-            if(!testingEmptyPathWithNonExistingResource)
                 assertThat("All mappings without request", mapper.getAllMappings(path), is(allMappings));
             if ( !path.isEmpty() ) // an empty path is invalid, hence not testing with a request
                 assertThat("All mappings with request", mapper.getAllMappings(path, request), is(allMappingsWithRequest));


### PR DESCRIPTION
This PR has the code changes for issue SLING-10844. Apparently earlier implementation of API getMapping() in ResourceMapperImpl.java was returning null in case the path was empty which was breaking the contract mentioned in corresponding interface so to fix code changes been made to return empty string (but not null).  
The test [0] would be fixed in further commit of this PR.
[0]:  https://github.com/apache/sling-org-apache-sling-resourceresolver/blob/master/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java#L173