### PR TITLE
SLING-10945 add metrics

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,5 +1,6 @@
 Import-Package:\
   javax.jcr;resolution:=optional,\
+  org.apache.sling.commons.metrics;resolution:=optional,\
   *
 
 Provide-Capability:\

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.metrics</artifactId>
             <version>1.2.8</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- For the Console Plugin of the ResourceResolverFactoryImpl -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
             <artifactId>annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.metrics</artifactId>
+            <version>1.2.8</version>
+        </dependency>
 
         <!-- For the Console Plugin of the ResourceResolverFactoryImpl -->
         <dependency>

--- a/src/main/java/org/apache/sling/resourceresolver/impl/CommonResourceResolverFactoryImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/CommonResourceResolverFactoryImpl.java
@@ -538,12 +538,14 @@ public class CommonResourceResolverFactoryImpl implements ResourceResolverFactor
             this.openingException = factory.logUnclosedResolvers && LOG.isInfoEnabled() ? new Exception("Opening Stacktrace") : null;
         }
 
-        public void close(ResourceResolverMetrics metrics) {
+        public void close(Optional<ResourceResolverMetrics> metrics) {
             try {
                 if (factory.unregisterControl(this.control) && factory.logUnclosedResolvers) {
                     if (factory.isLive()) {
                         LOG.warn("Closed unclosed ResourceResolver. The creation stacktrace is available on info log level.");
-                        metrics.reportUnclosedResourceResolver();
+                        if (metrics.isPresent()) {
+                            metrics.get().reportUnclosedResourceResolver();
+                        }
                     } else {
                         LOG.warn("Forced close of ResourceResolver because the ResourceResolverFactory is shutting down.");
                     }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
@@ -115,6 +115,7 @@ public class ResourceResolverFactoryActivator {
     @Reference
     ResourceAccessSecurityTracker resourceAccessSecurityTracker;
     
+    @SuppressWarnings("java:S3077")
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY, policy = ReferencePolicy.DYNAMIC)
     private volatile ResourceResolverMetrics metrics;
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
@@ -51,6 +51,7 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
@@ -114,7 +115,7 @@ public class ResourceResolverFactoryActivator {
     @Reference
     ResourceAccessSecurityTracker resourceAccessSecurityTracker;
     
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
     private ResourceResolverMetrics metrics;
 
     volatile ResourceProviderTracker resourceProviderTracker;
@@ -162,8 +163,8 @@ public class ResourceResolverFactoryActivator {
         return stringInterpolationProvider;
     }
     
-    public ResourceResolverMetrics getResourceResolverMetrics() {
-        return this.metrics;
+    public Optional<ResourceResolverMetrics> getResourceResolverMetrics() {
+        return Optional.ofNullable(this.metrics);
     }
 
     /**

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
@@ -115,8 +115,8 @@ public class ResourceResolverFactoryActivator {
     @Reference
     ResourceAccessSecurityTracker resourceAccessSecurityTracker;
     
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
-    private ResourceResolverMetrics metrics;
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY, policy = ReferencePolicy.DYNAMIC)
+    private volatile ResourceResolverMetrics metrics;
 
     volatile ResourceProviderTracker resourceProviderTracker;
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
@@ -113,6 +113,9 @@ public class ResourceResolverFactoryActivator {
 
     @Reference
     ResourceAccessSecurityTracker resourceAccessSecurityTracker;
+    
+    @Reference
+    private ResourceResolverMetrics metrics;
 
     volatile ResourceProviderTracker resourceProviderTracker;
 
@@ -158,6 +161,10 @@ public class ResourceResolverFactoryActivator {
     public StringInterpolationProvider getStringInterpolationProvider() {
         return stringInterpolationProvider;
     }
+    
+    public ResourceResolverMetrics getResourceResolverMetrics() {
+        return this.metrics;
+    }
 
     /**
      * This method is called from {@link MapEntries}
@@ -187,7 +194,7 @@ public class ResourceResolverFactoryActivator {
     }
 
     public boolean isMapConfiguration(String path) {
-        return path.equals(this.mapRoot)
+        return path.equals(this.getMapRoot())
                || path.startsWith(this.mapRootPrefix);
     }
 
@@ -526,7 +533,7 @@ public class ResourceResolverFactoryActivator {
                         }
                         final ResourceResolverFactoryImpl r = new ResourceResolverFactoryImpl(
                                 local.commonFactory, bundle,
-                            ResourceResolverFactoryActivator.this.serviceUserMapper);
+                            ResourceResolverFactoryActivator.this.getServiceUserMapper());
                         return r;
                     }
 
@@ -548,7 +555,7 @@ public class ResourceResolverFactoryActivator {
      * @return The runtime service
      */
     public RuntimeService getRuntimeService() {
-        return new RuntimeServiceImpl(this.resourceProviderTracker);
+        return new RuntimeServiceImpl(this.getResourceProviderTracker());
     }
 
     public ServiceUserMapper getServiceUserMapper() {
@@ -563,7 +570,7 @@ public class ResourceResolverFactoryActivator {
      * Check the preconditions and if it changed, either register factory or unregister
      */
     private void checkFactoryPreconditions(final String unavailableName, final String unavailableServicePid) {
-        final BundleContext localContext = this.bundleContext;
+        final BundleContext localContext = this.getBundleContext();
         if ( localContext != null ) {
             final boolean result = this.preconds.checkPreconditions(unavailableName, unavailableServicePid);
             if ( result && this.factoryRegistration == null ) {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
@@ -41,7 +41,7 @@ public class ResourceResolverMetrics {
     @Reference
     MetricsService metricsService;
     
-    private static Supplier<Long> ZERO_SUPPLIER = () -> 0L;
+    private static final Supplier<Long> ZERO_SUPPLIER = () -> 0L;
     
     // number of vanity paths
     private ServiceRegistration<Gauge<Long>> numberOfVanityPathsGauge;
@@ -101,7 +101,7 @@ public class ResourceResolverMetrics {
     private ServiceRegistration<Gauge<Long>> registerGauge(BundleContext context, String name, Supplier<Supplier<Long>> supplier) {
 
         ResourceResolverGauge gauge = new ResourceResolverGauge(supplier);
-        @SuppressWarnings("rawtypes,java:S1149")
+        @SuppressWarnings("all")
         Dictionary props = new Hashtable();
         props.put(Gauge.NAME, name);
         return context.registerService(Gauge.class, gauge, props);

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
@@ -36,6 +36,8 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service=ResourceResolverMetrics.class, immediate=true)
 public class ResourceResolverMetrics {
     
+    protected static final String METRICS_PREFIX = "org.apache.sling.resourceresolver";
+    
     @Reference
     MetricsService metricsService;
     
@@ -55,9 +57,9 @@ public class ResourceResolverMetrics {
     @Activate
     protected void activate(ComponentContext context) {
         BundleContext bundleContext = context.getBundleContext();
-        numberOfVanityPathsGauge = registerGauge(bundleContext, "numberOfVanityPaths", () -> numberOfVanityPathsSupplier );
-        numberOfAliasesGauge = registerGauge(bundleContext, "numberOfAliases", () -> numberOfAliasesSupplier );
-        unclosedResourceResolvers = metricsService.counter("unclosedResourceResolvers");
+        numberOfVanityPathsGauge = registerGauge(bundleContext, METRICS_PREFIX + ".numberOfVanityPaths", () -> numberOfVanityPathsSupplier );
+        numberOfAliasesGauge = registerGauge(bundleContext, METRICS_PREFIX + ".numberOfAliases", () -> numberOfAliasesSupplier );
+        unclosedResourceResolvers = metricsService.counter(METRICS_PREFIX  + ".unclosedResourceResolvers");
     }
     
     @Deactivate

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
@@ -27,13 +27,22 @@ import org.apache.sling.commons.metrics.Gauge;
 import org.apache.sling.commons.metrics.MetricsService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
-@Component(service=ResourceResolverMetrics.class, immediate=true)
+/**
+ *  Export metrics for the resource resolver bundle:
+ *  
+ *  org.apache.sling.resourceresolver.numberOfVanityPaths - the total number of vanity paths
+ *  org.apache.sling.resourceresolver.numberOfAliases  -- the total number of aliases
+ *  org.apache.sling.resourceresolver.unclosedResourceResolvers  -- the total number of unclosed resource resolvers
+ *
+ */
+
+
+@Component(service=ResourceResolverMetrics.class)
 public class ResourceResolverMetrics {
     
     protected static final String METRICS_PREFIX = "org.apache.sling.resourceresolver";
@@ -55,8 +64,7 @@ public class ResourceResolverMetrics {
     
     
     @Activate
-    protected void activate(ComponentContext context) {
-        BundleContext bundleContext = context.getBundleContext();
+    protected void activate(BundleContext bundleContext) {
         numberOfVanityPathsGauge = registerGauge(bundleContext, METRICS_PREFIX + ".numberOfVanityPaths", () -> numberOfVanityPathsSupplier );
         numberOfAliasesGauge = registerGauge(bundleContext, METRICS_PREFIX + ".numberOfAliases", () -> numberOfAliasesSupplier );
         unclosedResourceResolvers = metricsService.counter(METRICS_PREFIX  + ".unclosedResourceResolvers");
@@ -84,6 +92,9 @@ public class ResourceResolverMetrics {
         numberOfAliasesSupplier = supplier;
     }
     
+    /**
+     * Increment the counter for the number of unresolved resource resolvers
+     */
     public void reportUnclosedResourceResolver() {
         unclosedResourceResolvers.increment();
     }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
@@ -39,7 +39,7 @@ public class ResourceResolverMetrics {
     @Reference
     MetricsService metricsService;
     
-    Supplier<Long> NULL_SUPPLIER = () -> { return 0L; };
+    Supplier<Long> NULL_SUPPLIER = () -> 0L;
     
     // number of vanity paths
     private ServiceRegistration<Gauge<Long>> numberOfVanityPathsGauge;
@@ -55,8 +55,8 @@ public class ResourceResolverMetrics {
     @Activate
     protected void activate(ComponentContext context) {
         BundleContext bundleContext = context.getBundleContext();
-        numberOfVanityPathsGauge = registerGauge(bundleContext, "numberOfVanityPaths", () -> { return numberOfVanityPathsSupplier;} );
-        numberOfAliasesGauge = registerGauge(bundleContext, "numberOfAliases", () -> {return numberOfAliasesSupplier;} );
+        numberOfVanityPathsGauge = registerGauge(bundleContext, "numberOfVanityPaths", () -> numberOfVanityPathsSupplier );
+        numberOfAliasesGauge = registerGauge(bundleContext, "numberOfAliases", () -> numberOfAliasesSupplier );
         unclosedResourceResolvers = metricsService.counter("unclosedResourceResolvers");
     }
     
@@ -99,6 +99,7 @@ public class ResourceResolverMetrics {
     private ServiceRegistration<Gauge<Long>> registerGauge(BundleContext context, String name, Supplier<Supplier<Long>> supplier) {
 
         ResourceResolverGauge gauge = new ResourceResolverGauge(supplier);
+        @SuppressWarnings("rawtypes")
         Dictionary props = new Hashtable();
         props.put(Gauge.NAME, name);
         return context.registerService(Gauge.class, gauge, props);

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.impl;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.function.Supplier;
+
+import org.apache.sling.commons.metrics.Counter;
+import org.apache.sling.commons.metrics.Gauge;
+import org.apache.sling.commons.metrics.MetricsService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service=ResourceResolverMetrics.class, immediate=true)
+public class ResourceResolverMetrics {
+    
+    @Reference
+    MetricsService metricsService;
+    
+    Supplier<Long> NULL_SUPPLIER = () -> { return 0L; };
+    
+    // number of vanity paths
+    private ServiceRegistration<Gauge<Long>> numberOfVanityPathsGauge;
+    private Supplier<Long> numberOfVanityPathsSupplier = NULL_SUPPLIER;
+    
+    // number of aliases
+    private ServiceRegistration<Gauge<Long>> numberOfAliasesGauge;
+    private Supplier<Long> numberOfAliasesSupplier = NULL_SUPPLIER;
+    
+    private Counter unclosedResourceResolvers;
+    
+    
+    @Activate
+    protected void activate(ComponentContext context) {
+        BundleContext bundleContext = context.getBundleContext();
+        numberOfVanityPathsGauge = registerGauge(bundleContext, "numberOfVanityPaths", () -> { return numberOfVanityPathsSupplier;} );
+        numberOfAliasesGauge = registerGauge(bundleContext, "numberOfAliases", () -> {return numberOfAliasesSupplier;} );
+        unclosedResourceResolvers = metricsService.counter("unclosedResourceResolvers");
+    }
+    
+    @Deactivate
+    protected void deactivate() {
+        numberOfVanityPathsGauge.unregister();
+        numberOfAliasesGauge.unregister();
+    }
+    
+    /**
+     * Set the number of vanity paths in the system
+     * @param supplier a supplier returning the number of vanity paths
+     */
+    public void setNumberOfVanityPathsSupplier(Supplier<Long> supplier) {
+        numberOfVanityPathsSupplier = supplier;
+    }
+    
+    /**
+     * Set the number of aliases in the system
+     * @param supplier a supplier returning the number of aliases
+     */
+    public void setNumberOfAliasesSupplier(Supplier<Long> supplier) {
+        numberOfAliasesSupplier = supplier;
+    }
+    
+    public void reportUnclosedResourceResolver() {
+        unclosedResourceResolvers.increment();
+    }
+    
+    /**
+     * Create a gauge metrics.
+     *
+     * Sling Metrics does not directly offer a gauge as any other type, but only a whiteboard approach
+     * @param context the bundlecontext
+     * @param name the name of the metric
+     * @param supplier a supplier returning a supplier returning the requested value
+     * @return the ServiceRegistration for this metric (must be unregistered!)
+     */
+    @SuppressWarnings("unchecked")
+    private ServiceRegistration<Gauge<Long>> registerGauge(BundleContext context, String name, Supplier<Supplier<Long>> supplier) {
+
+        ResourceResolverGauge gauge = new ResourceResolverGauge(supplier);
+        Dictionary props = new Hashtable();
+        props.put(Gauge.NAME, name);
+        return context.registerService(Gauge.class, gauge, props);
+    }
+
+    public class ResourceResolverGauge implements Gauge<Long> {
+        Supplier<Supplier<Long>> supplier;
+
+        public ResourceResolverGauge(Supplier<Supplier<Long>> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public Long getValue() {
+            return supplier.get().get();
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetrics.java
@@ -41,15 +41,15 @@ public class ResourceResolverMetrics {
     @Reference
     MetricsService metricsService;
     
-    Supplier<Long> NULL_SUPPLIER = () -> 0L;
+    private static Supplier<Long> ZERO_SUPPLIER = () -> 0L;
     
     // number of vanity paths
     private ServiceRegistration<Gauge<Long>> numberOfVanityPathsGauge;
-    private Supplier<Long> numberOfVanityPathsSupplier = NULL_SUPPLIER;
+    private Supplier<Long> numberOfVanityPathsSupplier = ZERO_SUPPLIER;
     
     // number of aliases
     private ServiceRegistration<Gauge<Long>> numberOfAliasesGauge;
-    private Supplier<Long> numberOfAliasesSupplier = NULL_SUPPLIER;
+    private Supplier<Long> numberOfAliasesSupplier = ZERO_SUPPLIER;
     
     private Counter unclosedResourceResolvers;
     
@@ -101,7 +101,7 @@ public class ResourceResolverMetrics {
     private ServiceRegistration<Gauge<Long>> registerGauge(BundleContext context, String name, Supplier<Supplier<Long>> supplier) {
 
         ResourceResolverGauge gauge = new ResourceResolverGauge(supplier);
-        @SuppressWarnings("rawtypes")
+        @SuppressWarnings("rawtypes,java:S1149")
         Dictionary props = new Hashtable();
         props.put(Gauge.NAME, name);
         return context.registerService(Gauge.class, gauge, props);

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -105,7 +105,7 @@ public class MapEntries implements
 
     private volatile EventAdmin eventAdmin;
     
-    private volatile ResourceResolverMetrics metrics;
+    private ResourceResolverMetrics metrics;
 
     private volatile ServiceRegistration<ResourceChangeListener> registration;
 
@@ -168,8 +168,8 @@ public class MapEntries implements
 
         this.vanityBloomFilterFile = bundleContext.getDataFile(VANITY_BLOOM_FILTER_NAME);
         initializeVanityPaths();
-        metrics.setNumberOfVanityPathsSupplier(() -> { return vanityCounter.get();});
-        metrics.setNumberOfAliasesSupplier(() -> { return (long) aliasMap.size();});
+        this.metrics.setNumberOfVanityPathsSupplier(vanityCounter::get);
+        this.metrics.setNumberOfAliasesSupplier(() -> (long) aliasMap.size());
     }
 
     /**

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -92,7 +92,7 @@ public class MapEntries implements
 
     private static final String JCR_SYSTEM_PREFIX = JCR_SYSTEM_PATH + '/';
 
-   static final String ALIAS_BASE_QUERY_DEFAULT = "SELECT sling:alias FROM nt:base AS page";
+    static final String ALIAS_BASE_QUERY_DEFAULT = "SELECT sling:alias FROM nt:base AS page";
 
     static final String ANY_SCHEME_HOST = "[^/]+/[^/]+";
 
@@ -105,7 +105,7 @@ public class MapEntries implements
 
     private volatile EventAdmin eventAdmin;
     
-    private ResourceResolverMetrics metrics;
+    private Optional<ResourceResolverMetrics> metrics;
 
     private volatile ServiceRegistration<ResourceChangeListener> registration;
 
@@ -137,12 +137,13 @@ public class MapEntries implements
             final BundleContext bundleContext, 
             final EventAdmin eventAdmin, 
             final StringInterpolationProvider stringInterpolationProvider, 
-            final ResourceResolverMetrics metrics) throws LoginException, IOException {
+            final Optional<ResourceResolverMetrics> metrics) 
+                    throws LoginException, IOException {
 
     	this.resolver = factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo("mapping"));
         this.factory = factory;
         this.eventAdmin = eventAdmin;
-        this.metrics = metrics;
+
 
 
         this.resolveMapsMap = Collections.singletonMap(GLOBAL_LIST_KEY, Collections.emptyList());
@@ -168,8 +169,11 @@ public class MapEntries implements
 
         this.vanityBloomFilterFile = bundleContext.getDataFile(VANITY_BLOOM_FILTER_NAME);
         initializeVanityPaths();
-        this.metrics.setNumberOfVanityPathsSupplier(vanityCounter::get);
-        this.metrics.setNumberOfAliasesSupplier(() -> (long) aliasMap.size());
+        this.metrics = metrics;
+        if (metrics.isPresent()) {
+            this.metrics.get().setNumberOfVanityPathsSupplier(vanityCounter::get);
+            this.metrics.get().setNumberOfAliasesSupplier(() -> (long) aliasMap.size());
+        }
     }
 
     /**

--- a/src/test/java/org/apache/sling/resourceresolver/impl/EtcMappingResourceResolverTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/EtcMappingResourceResolverTest.java
@@ -85,6 +85,9 @@ public class EtcMappingResourceResolverTest {
 
     @Mock
     EventAdmin eventAdmin;
+    
+    @Mock
+    ResourceResolverMetrics metrics;
 
     @Mock
     ResourceResolver resourceResolver;
@@ -128,6 +131,8 @@ public class EtcMappingResourceResolverTest {
         setInaccessibleField("mapRoot", activator, "/etc/map");
         setInaccessibleField("mapRootPrefix", activator, "/etc/map");
         setInaccessibleField("observationPaths", activator, new Path[] {new Path("/")});
+        setInaccessibleField("metrics", activator, metrics);
+        
         ServiceUserMapper serviceUserMapper = mock(ServiceUserMapper.class);
         setInaccessibleField("serviceUserMapper", activator, serviceUserMapper);
         commonFactory = spy(new CommonResourceResolverFactoryImpl(activator));

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetricsTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetricsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.sling.commons.metrics.Gauge;
+import org.apache.sling.commons.metrics.MetricsService;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ResourceResolverMetricsTest {
+    
+    @Rule
+    public OsgiContext context = new OsgiContext();
+    
+    private MetricsService metricsService;
+    
+    private ResourceResolverMetrics metrics;
+    
+    @Before
+    public void setup() {
+        metrics = new ResourceResolverMetrics();
+        metricsService = Mockito.mock(MetricsService.class);
+        context.registerService(MetricsService.class, metricsService);
+        context.registerInjectActivateService(metrics);
+    }
+    
+    @Test
+    public void testGauges() {
+        Gauge<Long> vanityPaths =  getGauge("numberOfVanityPaths");
+        Gauge<Long> aliases = getGauge("numberOfAliases");
+        assertThat(vanityPaths.getValue(),is(0L));
+        assertThat(aliases.getValue(),is(0L));
+        
+        metrics.setNumberOfAliasesSupplier(() -> {return 3L;});
+        metrics.setNumberOfVanityPathsSupplier(() -> {return 2L;});
+        assertThat(vanityPaths.getValue(),is(2L));
+        assertThat(aliases.getValue(),is(3L));
+        
+    }
+    
+    @Test
+    public void testCounter() {
+        
+    }
+    
+    private Gauge<Long> getGauge(String name) {
+        String filter = String.format("(%s=%s)", Gauge.NAME,name);
+        Gauge<Long>[] result = context.getServices(Gauge.class,filter);
+        assertThat(result.length,is(1));
+        return result[0];
+    }
+
+}

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetricsTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetricsTest.java
@@ -48,8 +48,8 @@ public class ResourceResolverMetricsTest {
     
     @Test
     public void testGauges() {
-        Gauge<Long> vanityPaths =  getGauge("numberOfVanityPaths");
-        Gauge<Long> aliases = getGauge("numberOfAliases");
+        Gauge<Long> vanityPaths =  getGauge(ResourceResolverMetrics.METRICS_PREFIX + ".numberOfVanityPaths");
+        Gauge<Long> aliases = getGauge(ResourceResolverMetrics.METRICS_PREFIX + ".numberOfAliases");
         assertThat(vanityPaths.getValue(),is(0L));
         assertThat(aliases.getValue(),is(0L));
         

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetricsTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverMetricsTest.java
@@ -53,15 +53,10 @@ public class ResourceResolverMetricsTest {
         assertThat(vanityPaths.getValue(),is(0L));
         assertThat(aliases.getValue(),is(0L));
         
-        metrics.setNumberOfAliasesSupplier(() -> {return 3L;});
-        metrics.setNumberOfVanityPathsSupplier(() -> {return 2L;});
+        metrics.setNumberOfAliasesSupplier(() -> 3L);
+        metrics.setNumberOfVanityPathsSupplier(() -> 2L);
         assertThat(vanityPaths.getValue(),is(2L));
         assertThat(aliases.getValue(),is(3L));
-        
-    }
-    
-    @Test
-    public void testCounter() {
         
     }
     

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AbstractMappingMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AbstractMappingMapEntriesTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -78,8 +79,7 @@ public abstract class AbstractMappingMapEntriesTest {
     @Mock
     EventAdmin eventAdmin;
     
-    @Mock
-    ResourceResolverMetrics metrics;
+    Optional<ResourceResolverMetrics> metrics = Optional.empty();
 
     @Mock
     ResourceResolver resourceResolver;

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AbstractMappingMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AbstractMappingMapEntriesTest.java
@@ -23,6 +23,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.path.Path;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -76,6 +77,9 @@ public abstract class AbstractMappingMapEntriesTest {
 
     @Mock
     EventAdmin eventAdmin;
+    
+    @Mock
+    ResourceResolverMetrics metrics;
 
     @Mock
     ResourceResolver resourceResolver;
@@ -118,7 +122,7 @@ public abstract class AbstractMappingMapEntriesTest {
 
         stringInterpolationProviderConfiguration = createStringInterpolationProviderConfiguration();
         setupStringInterpolationProvider(stringInterpolationProvider, stringInterpolationProviderConfiguration, new String[] {});
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider);
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
 
         final Field aliasMapField = MapEntries.class.getDeclaredField("aliasMap");
         aliasMapField.setAccessible(true);

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/EtcMappingMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/EtcMappingMapEntriesTest.java
@@ -23,6 +23,7 @@ import org.apache.sling.resourceresolver.impl.CommonResourceResolverFactoryImpl;
 import org.apache.sling.resourceresolver.impl.ResourceAccessSecurityTracker;
 import org.apache.sling.resourceresolver.impl.ResourceResolverFactoryActivator;
 import org.apache.sling.resourceresolver.impl.ResourceResolverFactoryImpl;
+import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
 import org.apache.sling.resourceresolver.impl.providers.ResourceProviderHandler;
 import org.apache.sling.resourceresolver.impl.providers.ResourceProviderStorage;
 import org.apache.sling.resourceresolver.impl.providers.ResourceProviderTracker;
@@ -31,6 +32,7 @@ import org.apache.sling.spi.resource.provider.ResolveContext;
 import org.apache.sling.spi.resource.provider.ResourceContext;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
@@ -180,6 +182,7 @@ public class EtcMappingMapEntriesTest extends AbstractMappingMapEntriesTest {
         when(activator.getStringInterpolationProvider()).thenReturn(stringInterpolationProvider);
         when(activator.getMapRoot()).thenReturn("/etc/map");
         when(activator.getObservationPaths()).thenReturn(new Path[] {new Path("/")});
+        when(activator.getResourceResolverMetrics()).thenReturn(Mockito.mock(ResourceResolverMetrics.class));
         CommonResourceResolverFactoryImpl commonFactory = spy(new CommonResourceResolverFactoryImpl(activator));
         when(bundleContext.getBundle()).thenReturn(bundle);
         ServiceUserMapper serviceUserMapper = mock(ServiceUserMapper.class);

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/EtcMappingMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/EtcMappingMapEntriesTest.java
@@ -40,6 +40,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.apache.sling.resourceresolver.impl.MockedResourceResolverImplTest.createRPHandler;
@@ -182,7 +183,7 @@ public class EtcMappingMapEntriesTest extends AbstractMappingMapEntriesTest {
         when(activator.getStringInterpolationProvider()).thenReturn(stringInterpolationProvider);
         when(activator.getMapRoot()).thenReturn("/etc/map");
         when(activator.getObservationPaths()).thenReturn(new Path[] {new Path("/")});
-        when(activator.getResourceResolverMetrics()).thenReturn(Mockito.mock(ResourceResolverMetrics.class));
+        when(activator.getResourceResolverMetrics()).thenReturn(Optional.of(Mockito.mock(ResourceResolverMetrics.class)));
         CommonResourceResolverFactoryImpl commonFactory = spy(new CommonResourceResolverFactoryImpl(activator));
         when(bundleContext.getBundle()).thenReturn(bundle);
         ServiceUserMapper serviceUserMapper = mock(ServiceUserMapper.class);

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
@@ -46,6 +46,7 @@ import org.apache.sling.api.resource.observation.ResourceChange.ChangeType;
 import org.apache.sling.api.resource.path.Path;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.resourceresolver.impl.ResourceResolverImpl;
+import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
 import org.apache.sling.resourceresolver.impl.mapping.MapConfigurationProvider.VanityPathConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -73,6 +74,9 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
     @Mock
     private Bundle bundle;
+    
+    @Mock
+    private ResourceResolverMetrics metrics;
 
     @Mock
     private ResourceResolver resourceResolver;
@@ -125,7 +129,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         }
         when(resourceResolverFactory.getAllowedAliasLocations()).thenReturn(aliasPath);
 
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider);
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
         final Field aliasMapField = MapEntries.class.getDeclaredField("aliasMap");
         aliasMapField.setAccessible(true);
 
@@ -817,7 +821,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         addResource.setAccessible(true);
 
         when(resourceResolverFactory.isOptimizeAliasResolutionEnabled()).thenReturn(false);
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider);
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
 
         Resource parent = mock(Resource.class);
         when(parent.getPath()).thenReturn("/parent");
@@ -842,7 +846,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         addResource.setAccessible(true);
 
         when(resourceResolverFactory.isOptimizeAliasResolutionEnabled()).thenReturn(false);
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider);
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
 
         Resource parent = mock(Resource.class);
         when(parent.getPath()).thenReturn("/parent");
@@ -867,7 +871,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         removeAlias.setAccessible(true);
 
         when(resourceResolverFactory.isOptimizeAliasResolutionEnabled()).thenReturn(false);
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider);
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
 
         Resource parent = mock(Resource.class);
         when(parent.getPath()).thenReturn("/parent");
@@ -2195,7 +2199,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         // initialize with having vanity path disabled - must not throw errors here or on disposal
         when(resourceResolverFactory.isVanityPathEnabled()).thenReturn(false);
 
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider);
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
 
         mapEntries.doInit();
     }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
@@ -74,9 +74,6 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
     @Mock
     private Bundle bundle;
-    
-    @Mock
-    private ResourceResolverMetrics metrics;
 
     @Mock
     private ResourceResolver resourceResolver;
@@ -128,6 +125,8 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
           aliasPath.add("/parent"+i);
         }
         when(resourceResolverFactory.getAllowedAliasLocations()).thenReturn(aliasPath);
+        
+        Optional<ResourceResolverMetrics> metrics = Optional.empty();
 
         mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
         final Field aliasMapField = MapEntries.class.getDeclaredField("aliasMap");

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -42,6 +42,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.mapping.ResourceMapper;
 import org.apache.sling.resourceresolver.impl.ResourceAccessSecurityTracker;
 import org.apache.sling.resourceresolver.impl.ResourceResolverFactoryActivator;
+import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
 import org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
@@ -52,6 +53,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mockito;
 
 /**
  * Validates that the {@link ResourceMapperImpl} correctly queries all sources of mappings
@@ -78,8 +80,7 @@ public class ResourceMapperImplTest {
     public static Object[] data() {
         return new Object[] { false, true};
     }
-
-
+    
     @Rule
     public final OsgiContext ctx = new OsgiContext();
 
@@ -94,6 +95,7 @@ public class ResourceMapperImplTest {
     @Before
     public void prepare() throws LoginException {
 
+        ctx.registerService(ResourceResolverMetrics.class, Mockito.mock(ResourceResolverMetrics.class));
         ctx.registerInjectActivateService(new ServiceUserMapperImpl());
         ctx.registerInjectActivateService(new ResourceAccessSecurityTracker());
         ctx.registerInjectActivateService(new StringInterpolationProviderImpl());

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -95,7 +95,6 @@ public class ResourceMapperImplTest {
     @Before
     public void prepare() throws LoginException {
 
-        ctx.registerService(ResourceResolverMetrics.class, Mockito.mock(ResourceResolverMetrics.class));
         ctx.registerInjectActivateService(new ServiceUserMapperImpl());
         ctx.registerInjectActivateService(new ResourceAccessSecurityTracker());
         ctx.registerInjectActivateService(new StringInterpolationProviderImpl());


### PR DESCRIPTION
Currently we are quite short in terms of metrics, which allow us to observe some basic numbers for the ResourceResolver. This PR adds 3 basic metrics:

* total number of aliases
* total number of vanity paths
* the number of unclosed resourceResolvers (since the last restart of the RR bundle)

The implementation is straight forward, there is a single ```ResourceResolverMetrics``` service, which either registers the Gauge services into OSGI or directly uses the Counter from Sling Commons Metrics. Basic test coverage for the ```ResourceResolverMetrics``` is provided, but I haven't augmented the existing test cases with validations, that their operations properly reflect in the metrics.

I tested this PR locally with my AEM instance, and all 3 metrics are reflected as JMX objects:
* org.apache.sling.resourceresolver:name=org.apache.sling.resourceresolve.unclosedResourceResolvers,type=Metrics
* org.apache.sling.resourceresolver:name=org.apache.sling.resourceresolve.numberOfVanityPaths,type=Metrics
* org.apache.sling.resourceresolver:name=org.apache.sling.resourceresolve.numberOfAliases,type=Metrics

as well as Metrics (flat in the sling namespace):
* sling:org.apache.sling.resourceresolver.numberOfAliases
* sling:org.apache.sling.resourceresolve.numberOfVanityPaths
* sling:org.apache.sling.resourceresolve.unclosedResourceResolvers
