### PR TITLE
SLING-11138: run MockedResourceResolverImplTest with MapEntries populated

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntry.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntry.java
@@ -279,7 +279,7 @@ public class MapEntry implements Comparable<MapEntry> {
         final Matcher m = urlPattern.matcher(value);
         if (m.find()) {
             final String[] redirects = getRedirect();
-            final String[] results = new String[redirects.length];
+            final List<String> results = new ArrayList<>(redirects.length);
             for (int i = 0; i < redirects.length; i++) {
             	try {
             		String redirect = redirects[i];
@@ -298,14 +298,12 @@ public class MapEntry implements Comparable<MapEntry> {
             				}
             			}
             		}
-            		results[i] = m.replaceFirst(redirect);
-            	} catch (final StringIndexOutOfBoundsException siob){
-            		log.debug("Exception while replacing, ignoring entry {} ", redirects[i], siob);
-                } catch (final IllegalArgumentException iae){
-                    log.debug("Exception while replacing, ignoring entry {} ", redirects[i], iae);
-             	}
+            		results.add(m.replaceFirst(redirect));
+            	} catch (final StringIndexOutOfBoundsException | IllegalArgumentException ex){
+            		log.debug("Exception while replacing, ignoring entry {} ", redirects[i], ex);
+                }
             }
-            return results;
+            return results.size() > 0 ? results.toArray(new String[0]) : null;
         }
 
         return null;

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntry.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntry.java
@@ -303,7 +303,7 @@ public class MapEntry implements Comparable<MapEntry> {
             		log.debug("Exception while replacing, ignoring entry {} ", redirects[i], ex);
                 }
             }
-            return results.size() > 0 ? results.toArray(new String[0]) : null;
+            return !results.isEmpty() ? results.toArray(new String[0]) : null;
         }
 
         return null;

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -174,9 +174,11 @@ public class ResourceMapperImpl implements ResourceMapper {
             mappings.replaceAll(path -> path.concat(fragmentQuery));
         }
 
-        mappings.forEach( path ->
-            logger.debug("map: Returning URL {} as mapping for path {}", path, resourcePath)    
-        );
+        if (logger.isDebugEnabled()) {
+            mappings.forEach(path ->
+                logger.debug("map: Returning URL {} as mapping for path {}", path, resourcePath)
+            );
+        }
         
         Collections.reverse(mappings);
         

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -17,9 +17,11 @@
  */
 package org.apache.sling.resourceresolver.impl;
 
+import static org.apache.sling.resourceresolver.util.MockTestUtil.getInaccessibleField;
 import static org.apache.sling.resourceresolver.util.MockTestUtil.getResourceName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -325,6 +327,11 @@ public class MockedResourceResolverImplTest {
         for (String path : activator.getAllowedAliasLocations()) {
             assertFalse("Path must not end with '/': " + path, StringUtils.endsWith(path, "/"));
         }
+
+        // ensure mappings are set
+        assertNotEquals("Mappings unavailable",
+            MapEntries.EMPTY,
+            getInaccessibleField("commonFactory",rrf,CommonResourceResolverFactoryImpl.class).getMapEntries());
     }
 
     public static ResourceProviderHandler createRPHandler(ResourceProvider<?> rp, String pid, long ranking,
@@ -541,6 +548,7 @@ public class MockedResourceResolverImplTest {
         Mockito.when(request.getScheme()).thenReturn("http");
         Mockito.when(request.getServerPort()).thenReturn(80);
         Mockito.when(request.getServerName()).thenReturn("localhost");
+
         String path = resourceResolver.map(request,"/single/test?q=123123");
         Assert.assertEquals("/single/test?q=123123", path);
         buildResource("/single/test", EMPTY_RESOURCE_LIST, resourceResolver, resourceProvider);

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -24,6 +24,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -48,6 +52,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.resourceresolver.impl.mapping.MapEntries;
+import org.apache.sling.resourceresolver.impl.mapping.StringInterpolationProvider;
 import org.apache.sling.resourceresolver.impl.observation.ResourceChangeListenerWhiteboard;
 import org.apache.sling.resourceresolver.impl.providers.ResourceProviderHandler;
 import org.apache.sling.resourceresolver.impl.providers.ResourceProviderInfo;
@@ -148,13 +153,12 @@ public class MockedResourceResolverImplTest {
         activator = new ResourceResolverFactoryActivator();
 
         // system bundle access
-        final Bundle systemBundle = Mockito.mock(Bundle.class);
+        final Bundle systemBundle = mock(Bundle.class);
         Mockito.when(systemBundle.getState()).thenReturn(Bundle.ACTIVE);
         Mockito.when(bundleContext.getBundle(Constants.SYSTEM_BUNDLE_LOCATION)).thenReturn(systemBundle);
         activator.resourceAccessSecurityTracker = new ResourceAccessSecurityTracker();
         activator.resourceProviderTracker = resourceProviderTracker;
         activator.changeListenerWhiteboard = resourceChangeListenerWhiteboard;
-        activator.serviceUserMapper = Mockito.mock(ServiceUserMapper.class);
         handlers.add(createRPHandler(resourceProvider, "org.apache.sling.resourceresolver.impl.DummyTestProvider", 10L, "/"));
 
         // setup mapping resources at /etc/map to exercise vanity etc.
@@ -169,8 +173,13 @@ public class MockedResourceResolverImplTest {
         Mockito.when(queriableResourceProviderA.getQueryLanguageProvider()).thenReturn(queryProvider);
 
         ResourceProviderStorage storage = new ResourceProviderStorage(handlers);
-
         Mockito.when(resourceProviderTracker.getResourceProviderStorage()).thenReturn(storage);
+
+        activator.serviceUserMapper = mock(ServiceUserMapper.class);
+        when(activator.serviceUserMapper.getServicePrincipalNames(any(), any())).thenReturn(Collections.singletonList("user"));
+
+        activator.stringInterpolationProvider = mock(StringInterpolationProvider.class);
+        when(activator.stringInterpolationProvider.substitute(anyString())).thenAnswer(inv -> (String) inv.getArguments()[0]);
 
         // activate the components.
         activator.activate(bundleContext, new ResourceResolverFactoryConfig() {
@@ -336,8 +345,8 @@ public class MockedResourceResolverImplTest {
 
     public static ResourceProviderHandler createRPHandler(ResourceProvider<?> rp, String pid, long ranking,
             String path) {
-        ServiceReference ref = Mockito.mock(ServiceReference.class);
-        BundleContext bc = Mockito.mock(BundleContext.class);
+        ServiceReference ref = mock(ServiceReference.class);
+        BundleContext bc = mock(BundleContext.class);
         Mockito.when(bc.getService(Mockito.eq(ref))).thenReturn(rp);
         Mockito.when(ref.getProperty(Mockito.eq(Constants.SERVICE_ID))).thenReturn(new Random().nextLong());
         Mockito.when(ref.getProperty(Mockito.eq(Constants.SERVICE_PID))).thenReturn(pid);
@@ -419,7 +428,7 @@ public class MockedResourceResolverImplTest {
      */
     @SuppressWarnings("unchecked")
     private Resource buildResource(String fullpath, Iterable<Resource> children, ResourceResolver resourceResolver, ResourceProvider<?> provider, String ... properties) {
-        Resource resource = Mockito.mock(Resource.class);
+        Resource resource = mock(Resource.class);
         Mockito.when(resource.getName()).thenReturn(getResourceName(fullpath));
         Mockito.when(resource.getPath()).thenReturn(fullpath);
         ResourceMetadata resourceMetadata = new ResourceMetadata();
@@ -544,7 +553,7 @@ public class MockedResourceResolverImplTest {
     public void testMapping() throws LoginException {
         ResourceResolver resourceResolver = resourceResolverFactory.getResourceResolver(null);
         buildResource("/single/test", EMPTY_RESOURCE_LIST, resourceResolver, resourceProvider);
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
         Mockito.when(request.getScheme()).thenReturn("http");
         Mockito.when(request.getServerPort()).thenReturn(80);
         Mockito.when(request.getServerName()).thenReturn("localhost");


### PR DESCRIPTION
In this change we make sure that the `MapEntries` are properly populated when constructing the unit under test. This caused the `testMapping()` test to fail in `MapEntries#replace()` for 

```
// applied MapEntry: /content.html-/$
java.lang.IllegalArgumentException: Illegal group reference: group index is missing
	at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1030)
	at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:998)
	at java.base/java.util.regex.Matcher.replaceFirst(Matcher.java:1408)
	at org.apache.sling.resourceresolver.impl.mapping.MapEntry.replace(MapEntry.java:301)
	at org.apache.sling.resourceresolver.impl.mapping.ResourceMapperImpl.populateMappingsFromMapEntries(ResourceMapperImpl.java:267)
	at org.apache.sling.resourceresolver.impl.mapping.ResourceMapperImpl.getAllMappings(ResourceMapperImpl.java:142)
	at org.apache.sling.resourceresolver.impl.mapping.ResourceMapperImpl.getMapping(ResourceMapperImpl.java:73)
	at org.apache.sling.resourceresolver.impl.ResourceResolverImpl.map(ResourceResolverImpl.java:447)
	at org.apache.sling.resourceresolver.impl.ResourceResolverImpl.map(ResourceResolverImpl.java:434)
	at org.apache.sling.resourceresolver.impl.MockedResourceResolverImplTest.testMapping(MockedResourceResolverImplTest.java:573)
```

This is because the regular expression substitution runs in an IAE with the substitution pattern `/$` which has a "wrong" group reference. It caused a `[null]` array being returned.

@cziegeler I am not sure what the expected outcome of the mapping rule should be `/content.html-/$`, any thoughts?