### PR TITLE
SLING-10844 - ResourceMapper.getMapping() returns null for empty path

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -163,8 +163,9 @@ public class ResourceMapperImpl implements ResourceMapper {
         mappings.addAll(0, vanityPaths);
 
         // 7. final effort to make sure we have at least one mapped path
-        if ( mappings.isEmpty() && nonDecoratedResource != null )
-            mappings.add(nonDecoratedResource.getPath());
+        if ( mappings.isEmpty() ) {
+            mappings.add(nonDecoratedResource != null ? nonDecoratedResource.getPath() : "/");
+        }
 
         // 8. apply context path if needed
         mappings.replaceAll(new ApplyContextPath(request));


### PR DESCRIPTION
The final effort to return at least one mapped path should handle the case when the user does
not have read access to the root path.