### PR TITLE
SLING-11352 - Fix parsing of path-only mappings

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntry.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntry.java
@@ -127,7 +127,7 @@ public class MapEntry implements Comparable<MapEntry> {
     public static String toURI(final String uriPath) {
         for (int i = 0; i < PATH_TO_URL_MATCH.length; i++) {
             final Matcher m = PATH_TO_URL_MATCH[i].matcher(uriPath);
-            if (m.find()) {
+            if (m.matches()) {
                 return m.replaceAll(PATH_TO_URL_REPLACEMENT[i]);
             }
         }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryTest.java
@@ -32,6 +32,11 @@ import org.junit.Test;
 
 public class MapEntryTest {
 
+    @Test public void test_regular_path() {
+        // regular paths should return null like the Javadoc says
+        assertNull(MapEntry.toURI("/the/path"));
+    }
+
     @Test public void test_to_url_http_80() {
         assertEqualUri("http://sling.apache.org", "http/sling.apache.org.80");
         assertEqualUri("http://sling.apache.org/", "http/sling.apache.org.80/");


### PR DESCRIPTION
It wasn't possible to add a regular path-only mapping to /etc/map because the sling:match property was mis-parsed as a URI.