### PR TITLE
SLING-11671 - Jenkins: allow running Sling Starter ITs with a given module based on the Sling module descriptor

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,0 +1,9 @@
+{
+  "jenkins": {
+     "starterITExecutions": {
+        "13-SNAPSHOT": {
+           "jdks:" [8, 11]
+         }
+      }
+   }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,5 @@
  * under the License.
  */
 
+@Library('sling@feature/SLING-11671')
 slingOsgiBundleBuild()


### PR DESCRIPTION
Run Sling Starter ITs with the build and pick up the Jenkinsfile from a branch