### PR TITLE
[SLING-11742] Provide alternative equitable terminology for properties

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
@@ -81,46 +81,6 @@ public class ResourceResolverFactoryActivator {
         public volatile CommonResourceResolverFactoryImpl commonFactory;
     }
 
-    private static final class VanityPathConfigurer {
-        private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-        void configureVanityPathPrefixes(String[] pathPrefixes, String[] pathPrefixesFallback,
-                                         String pathPrefixesPropertyName, String pathPrefixesFallbackPropertyName,
-                                         Consumer<String[]> filteredPathPrefixesConsumer) {
-            if (pathPrefixes != null) {
-                configureVanityPathPrefixes(pathPrefixes, filteredPathPrefixesConsumer);
-            } else {
-                logger.debug("The " + pathPrefixesPropertyName + " was null. Using the " +
-                    pathPrefixesFallbackPropertyName + " instead if defined.");
-                if (pathPrefixesFallback != null) {
-                    configureVanityPathPrefixes(pathPrefixesFallback, filteredPathPrefixesConsumer);
-                }
-            }
-        }
-
-        private static void configureVanityPathPrefixes(String[] pathPrefixes, Consumer<String[]> pathPrefixesConsumer) {
-            final List<String> filterVanityPaths = filterVanityPathPrefixes(pathPrefixes);
-            if (filterVanityPaths.size() > 0) {
-                pathPrefixesConsumer.accept(filterVanityPaths.toArray(new String[filterVanityPaths.size()]));
-            }
-        }
-
-        @NotNull
-        private static List<String> filterVanityPathPrefixes(String[] vanityPathPrefixes) {
-            final List<String> prefixList = new ArrayList<>();
-            for (final String value : vanityPathPrefixes) {
-                if (value.trim().length() > 0) {
-                    if (value.trim().endsWith("/")) {
-                        prefixList.add(value.trim());
-                    } else {
-                        prefixList.add(value.trim() + "/");
-                    }
-                }
-            }
-            return prefixList;
-        }
-    }
-
     /** Logger. */
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -385,16 +345,16 @@ public class ResourceResolverFactoryActivator {
         // vanity path white list
         this.vanityPathWhiteList = null;
         vanityPathConfigurer.configureVanityPathPrefixes(config.resource_resolver_vanitypath_whitelist(),
-            config.resource_resolver_vanitypath_allowedlist(),
+            config.resource_resolver_vanitypath_allowlist(),
             "resource_resolver_vanitypath_whitelist",
-            "resource_resolver_vanitypath_allowedlist",
+            "resource_resolver_vanitypath_allowlist",
             filteredPrefixes -> this.vanityPathWhiteList = filteredPrefixes);
         // vanity path black list
         this.vanityPathBlackList = null;
         vanityPathConfigurer.configureVanityPathPrefixes(config.resource_resolver_vanitypath_blacklist(),
-            config.resource_resolver_vanitypath_deniedlist(),
+            config.resource_resolver_vanitypath_denylist(),
             "resource_resolver_vanitypath_blacklist",
-            "resource_resolver_vanitypath_deniedlist",
+            "resource_resolver_vanitypath_denylist",
             filteredPrefixes -> this.vanityPathBlackList = filteredPrefixes);
 
         // check for required property

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryConfig.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryConfig.java
@@ -163,7 +163,7 @@ public @interface ResourceResolverFactoryConfig {
     @AttributeDefinition(name = "Allowed Vanity Path Location",
         description ="This setting can contain a list of path prefixes, e.g. /libs/, /content/. If " +
                     "such a list is configured, only vanity paths from resources starting with this prefix " +
-                    " are considered. If the list is empty, we fallback to resource_resolver_vanitypath_allowedlist.")
+                    " are considered. If the list is empty, we fallback to resource.resolver.vanitypath.allowlist.")
     String[] resource_resolver_vanitypath_whitelist();
 
     @AttributeDefinition(name = "Allowed Vanity Path Location",
@@ -175,7 +175,7 @@ public @interface ResourceResolverFactoryConfig {
     @AttributeDefinition(name = "Denied Vanity Path Location",
         description ="This setting can contain a list of path prefixes, e.g. /misc/. If " +
                     "such a list is configured,vanity paths from resources starting with this prefix " +
-                    " are not considered. If the list is empty, we fallback to resource_resolver_vanitypath_deniedlist.")
+                    " are not considered. If the list is empty, we fallback to resource.resolver.vanitypath.denylist.")
     String[] resource_resolver_vanitypath_blacklist();
 
     @AttributeDefinition(name = "Denied Vanity Path Location",

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryConfig.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryConfig.java
@@ -163,14 +163,26 @@ public @interface ResourceResolverFactoryConfig {
     @AttributeDefinition(name = "Allowed Vanity Path Location",
         description ="This setting can contain a list of path prefixes, e.g. /libs/, /content/. If " +
                     "such a list is configured, only vanity paths from resources starting with this prefix " +
-                    " are considered. If the list is empty, all vanity paths are used.")
+                    " are considered. If the list is empty, we fallback to resource_resolver_vanitypath_allowedlist.")
     String[] resource_resolver_vanitypath_whitelist();
+
+    @AttributeDefinition(name = "Allowed Vanity Path Location",
+        description ="This setting can contain a list of path prefixes, e.g. /libs/, /content/. If " +
+            "such a list is configured, only vanity paths from resources starting with this prefix " +
+            " are considered. If the list is empty, all vanity paths are used.")
+    String[] resource_resolver_vanitypath_allowedlist();
 
     @AttributeDefinition(name = "Denied Vanity Path Location",
         description ="This setting can contain a list of path prefixes, e.g. /misc/. If " +
                     "such a list is configured,vanity paths from resources starting with this prefix " +
-                    " are not considered. If the list is empty, all vanity paths are used.")
+                    " are not considered. If the list is empty, we fallback to resource_resolver_vanitypath_deniedlist.")
     String[] resource_resolver_vanitypath_blacklist();
+
+    @AttributeDefinition(name = "Denied Vanity Path Location",
+        description ="This setting can contain a list of path prefixes, e.g. /misc/. If " +
+            "such a list is configured,vanity paths from resources starting with this prefix " +
+            " are not considered. If the list is empty, all vanity paths are used.")
+    String[] resource_resolver_vanitypath_deniedlist();
 
     @AttributeDefinition(name = "Vanity Path Precedence",
         description ="This flag controls whether vanity paths" +

--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryConfig.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryConfig.java
@@ -170,7 +170,7 @@ public @interface ResourceResolverFactoryConfig {
         description ="This setting can contain a list of path prefixes, e.g. /libs/, /content/. If " +
             "such a list is configured, only vanity paths from resources starting with this prefix " +
             " are considered. If the list is empty, all vanity paths are used.")
-    String[] resource_resolver_vanitypath_allowedlist();
+    String[] resource_resolver_vanitypath_allowlist();
 
     @AttributeDefinition(name = "Denied Vanity Path Location",
         description ="This setting can contain a list of path prefixes, e.g. /misc/. If " +
@@ -182,7 +182,7 @@ public @interface ResourceResolverFactoryConfig {
         description ="This setting can contain a list of path prefixes, e.g. /misc/. If " +
             "such a list is configured,vanity paths from resources starting with this prefix " +
             " are not considered. If the list is empty, all vanity paths are used.")
-    String[] resource_resolver_vanitypath_deniedlist();
+    String[] resource_resolver_vanitypath_denylist();
 
     @AttributeDefinition(name = "Vanity Path Precedence",
         description ="This flag controls whether vanity paths" +

--- a/src/main/java/org/apache/sling/resourceresolver/impl/VanityPathConfigurer.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/VanityPathConfigurer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class VanityPathConfigurer {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    void configureVanityPathPrefixes(String[] pathPrefixes, String[] pathPrefixesFallback,
+                                     String pathPrefixesPropertyName, String pathPrefixesFallbackPropertyName,
+                                     Consumer<String[]> filteredPathPrefixesConsumer) {
+        if (pathPrefixes != null && pathPrefixesFallback != null) {
+            logger.warn("Both the " + pathPrefixesPropertyName + " and " + pathPrefixesFallbackPropertyName
+                + " were defined. Using " + pathPrefixesPropertyName + " for configuring vanity paths.");
+            configureVanityPathPrefixes(pathPrefixes, filteredPathPrefixesConsumer);
+        } else if (pathPrefixes != null) {
+            configureVanityPathPrefixes(pathPrefixes, filteredPathPrefixesConsumer);
+        } else {
+            logger.debug("The " + pathPrefixesPropertyName + " was null. Using the " +
+                pathPrefixesFallbackPropertyName + " instead if defined.");
+            if (pathPrefixesFallback != null) {
+                configureVanityPathPrefixes(pathPrefixesFallback, filteredPathPrefixesConsumer);
+            }
+        }
+    }
+
+    private static void configureVanityPathPrefixes(String[] pathPrefixes, Consumer<String[]> pathPrefixesConsumer) {
+        final List<String> filterVanityPaths = filterVanityPathPrefixes(pathPrefixes);
+        if (filterVanityPaths.size() > 0) {
+            pathPrefixesConsumer.accept(filterVanityPaths.toArray(new String[filterVanityPaths.size()]));
+        }
+    }
+
+    @NotNull
+    private static List<String> filterVanityPathPrefixes(String[] vanityPathPrefixes) {
+        final List<String> prefixList = new ArrayList<>();
+        for (final String value : vanityPathPrefixes) {
+            if (value.trim().length() > 0) {
+                if (value.trim().endsWith("/")) {
+                    prefixList.add(value.trim());
+                } else {
+                    prefixList.add(value.trim() + "/");
+                }
+            }
+        }
+        return prefixList;
+    }
+}

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -195,11 +195,11 @@ public class MockedResourceResolverImplTest {
 
             @Override
             public String[] resource_resolver_vanitypath_whitelist() {
-                return resource_resolver_vanitypath_allowedlist();
+                return null;
             }
 
             @Override
-            public String[] resource_resolver_vanitypath_allowedlist() {
+            public String[] resource_resolver_vanitypath_allowlist() {
                 return null;
             }
 
@@ -220,11 +220,11 @@ public class MockedResourceResolverImplTest {
 
             @Override
             public String[] resource_resolver_vanitypath_blacklist() {
-                return resource_resolver_vanitypath_deniedlist();
+                return null;
             }
 
             @Override
-            public String[] resource_resolver_vanitypath_deniedlist() {
+            public String[] resource_resolver_vanitypath_denylist() {
                 return null;
             }
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -195,6 +195,11 @@ public class MockedResourceResolverImplTest {
 
             @Override
             public String[] resource_resolver_vanitypath_whitelist() {
+                return resource_resolver_vanitypath_allowedlist();
+            }
+
+            @Override
+            public String[] resource_resolver_vanitypath_allowedlist() {
                 return null;
             }
 
@@ -215,6 +220,11 @@ public class MockedResourceResolverImplTest {
 
             @Override
             public String[] resource_resolver_vanitypath_blacklist() {
+                return resource_resolver_vanitypath_deniedlist();
+            }
+
+            @Override
+            public String[] resource_resolver_vanitypath_deniedlist() {
                 return null;
             }
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/VanityPathConfigurerTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/VanityPathConfigurerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+
+public class VanityPathConfigurerTest {
+    private VanityPathConfigurer vanityPathConfigurer;
+
+    @Before
+    public void before() {
+        vanityPathConfigurer = new VanityPathConfigurer();
+    }
+
+    @Test
+    public void testConfigureVanityPathPrefixes_givenBothPathPrefixAndFallBack_thenPathPrefixIsUsed() {
+        String[] pathPrefixes = {"/some/path/"};
+        String[] pathPrefixesFallback = {"/some/fallback/path/"};
+
+        vanityPathConfigurer.configureVanityPathPrefixes(pathPrefixes, pathPrefixesFallback,
+            "resource_resolver_vanitypath_whitelist",
+            "resource_resolver_vanitypath_allowlist",
+            actualResults -> verifyResults(actualResults, pathPrefixes));
+    }
+
+    @Test
+    public void testConfigureVanityPathPrefixes_givenOnlyPathPrefix_thenPathPrefixIsUsed() {
+        String[] pathPrefixes = {"/some/path/"};
+        String[] pathPrefixesFallback = null;
+
+        vanityPathConfigurer.configureVanityPathPrefixes(pathPrefixes, pathPrefixesFallback,
+            "resource_resolver_vanitypath_whitelist",
+            "resource_resolver_vanitypath_allowlist",
+            actualResults -> verifyResults(actualResults, pathPrefixes));
+    }
+
+    @Test
+    public void testConfigureVanityPathPrefixes_givenOnlyPathPrefixFallback_thenPathPrefixFallbackIsUsed() {
+        String[] pathPrefixes = null;
+        String[] pathPrefixesFallback = {"/some/fallback/path/"};
+
+        vanityPathConfigurer.configureVanityPathPrefixes(pathPrefixes, pathPrefixesFallback,
+            "resource_resolver_vanitypath_whitelist",
+            "resource_resolver_vanitypath_allowlist",
+            actualResults -> verifyResults(actualResults, pathPrefixesFallback));
+    }
+
+    private void verifyResults(String[] actualResults, String[] expectedResults) {
+        assertArrayEquals(expectedResults, actualResults);
+    }
+
+}


### PR DESCRIPTION
This PR introduces alternative terminology for terms that are considered un-appropriate for vanity paths, as described in [1]. The approach taken was to provide additional properties to the existing properties so that backwards compatibility is kept. For the sake of backwards compatibility, the existing vanity paths properties are checked first and if these are not defined, the newly introduced properties are checked. A log message is produced in this case.

[1] https://issues.apache.org/jira/browse/SLING-11742