### PR TITLE
SLING-11757: resource resolver: pathless URL in vanity path causes NPE in ResourceMapperImpl.apply()

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -364,7 +364,7 @@ public class ResourceMapperImpl implements ResourceMapper {
                 final URI uri = new URI(path, false);
 
                 // 1. mangle the namespaces in the path
-                path = mangleNamespaces(uri.getPath());
+                path = mangleNamespaces(uri.getPath() == null ? "/" : uri.getPath());
 
                 // 2. prepend servlet context path if we have a request
                 if (req != null && req.getContextPath() != null && req.getContextPath().length() > 0) {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -364,7 +364,7 @@ public class ResourceMapperImpl implements ResourceMapper {
                 final URI uri = new URI(path, false);
 
                 // 1. mangle the namespaces in the path
-                path = mangleNamespaces(uri.getPath() == null ? "/" : uri.getPath());
+                path = mangleNamespaces(uri.getPath() == null ? "" : uri.getPath());
 
                 // 2. prepend servlet context path if we have a request
                 if (req != null && req.getContextPath() != null && req.getContextPath().length() > 0) {

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -392,13 +392,13 @@ public class ResourceMapperImplTest {
     /**
      * Validates that vanity paths are returned as mappings, URL shaped variants, empty path (see see SLING-11757)
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void mapResourceWithVanityPathsURLTargetNoPath() {
         ExpectedMappings.existingResource("/vain-url-nopath")
             .singleMapping("/vain-url-nopath")
             .singleMappingWithRequest("/app/vain-url-nopath")
-            .allMappings("/vain-url-nopath", "see SLING-11757")
-            .allMappingsWithRequest("/app/vain-url-nopath", "see SLING-11757")
+            .allMappings("/vain-url-nopath", "")
+            .allMappingsWithRequest("/app/vain-url-nopath", "")
             .verify(resolver, req);
     }
 


### PR DESCRIPTION
…