### PR TITLE
SLING-12019 - Avoid duplicate ResourceResolverFactory registrations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,20 +188,32 @@
 
         <!-- Testing -->
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit-addons</groupId>
-            <artifactId>junit-addons</artifactId>
-            <version>1.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -218,8 +230,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
+            <version>3.3.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
-            <version>3.2.2</version>
+            <version>3.3.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/resourceresolver/impl/FactoryRegistrationHandlerTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/FactoryRegistrationHandlerTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(OsgiContextExtension.class)
 public class FactoryRegistrationHandlerTest {
 
-    private static final int DEFAULT_TEST_ITERATIONS = 10000;
+    private static final int DEFAULT_TEST_ITERATIONS = 20;
 
     private static final @NotNull Matcher<Iterable<? extends ServiceEventDTO>> RRF_REGISTRATION = allOf(
             hasSize(4),

--- a/src/test/java/org/apache/sling/resourceresolver/impl/FactoryRegistrationHandlerTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/FactoryRegistrationHandlerTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(OsgiContextExtension.class)
-public class FactoryRegistrationHandlerTest {
+class FactoryRegistrationHandlerTest {
 
     private static final int DEFAULT_TEST_ITERATIONS = 20;
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/FactoryRegistrationHandlerTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/FactoryRegistrationHandlerTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(OsgiContextExtension.class)
 public class FactoryRegistrationHandlerTest {
 
-    public static final int DEFAULT_TEST_ITERATIONS = 20;
+    private static final int DEFAULT_TEST_ITERATIONS = 10000;
 
     private static final @NotNull Matcher<Iterable<? extends ServiceEventDTO>> RRF_REGISTRATION = allOf(
             hasSize(4),
@@ -69,12 +69,12 @@ public class FactoryRegistrationHandlerTest {
             hasItem(registration(ResourceResolverFactory.class))
     );
 
-    public OsgiContext osgi = new OsgiContext();
+    OsgiContext osgi = new OsgiContext();
 
     private ResourceResolverFactoryActivator activator;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         final ResourceProviderTracker resourceProviderTracker = mock(ResourceProviderTracker.class);
         doReturn(mock(ResourceProviderStorage.class)).when(resourceProviderTracker).getResourceProviderStorage();
 
@@ -96,7 +96,7 @@ public class FactoryRegistrationHandlerTest {
     }
 
     @RepeatedTest(DEFAULT_TEST_ITERATIONS)
-    public void testFactoryRegistrationDeregistration() throws InterruptedException {
+    void testFactoryRegistrationDeregistration() throws InterruptedException {
         final BundleContext bundleContext = osgi.bundleContext();
         final FactoryPreconditions preconditions = mock(FactoryPreconditions.class);
         when(preconditions.checkPreconditions(isNull(), isNull())).thenReturn(true);
@@ -121,7 +121,7 @@ public class FactoryRegistrationHandlerTest {
     }
 
     @RepeatedTest(DEFAULT_TEST_ITERATIONS)
-    public void testConditionChangeLeadingToUnregistration() throws InterruptedException {
+    void testConditionChangeLeadingToUnregistration() throws InterruptedException {
         final BundleContext ctx = osgi.bundleContext();
         final FactoryPreconditions preconditions = mock(FactoryPreconditions.class);
 
@@ -142,7 +142,7 @@ public class FactoryRegistrationHandlerTest {
 
 
     @RepeatedTest(DEFAULT_TEST_ITERATIONS)
-    public void testReconfigurationLeadingToUnregsitration() throws InterruptedException {
+    void testReconfigurationLeadingToUnregsitration() throws InterruptedException {
         final BundleContext ctx = osgi.bundleContext();
         final FactoryPreconditions preconditions = mock(FactoryPreconditions.class);
         when(preconditions.checkPreconditions(isNull(), isNull())).thenReturn(true);
@@ -162,7 +162,7 @@ public class FactoryRegistrationHandlerTest {
         }
     }
     @RepeatedTest(DEFAULT_TEST_ITERATIONS)
-    public void testReconfigurationWithNoChanges() throws InterruptedException {
+    void testReconfigurationWithNoChanges() throws InterruptedException {
         final BundleContext ctx = osgi.bundleContext();
         final FactoryPreconditions preconditions = mock(FactoryPreconditions.class);
         when(preconditions.checkPreconditions(isNull(), isNull())).thenReturn(true);
@@ -181,7 +181,7 @@ public class FactoryRegistrationHandlerTest {
     }
 
     @RepeatedTest(DEFAULT_TEST_ITERATIONS)
-    public void testReconfigurationLeadingToReregistration() throws InterruptedException {
+    void testReconfigurationLeadingToReregistration() throws InterruptedException {
         final BundleContext ctx = osgi.bundleContext();
 
         try (final FactoryRegistrationHandler factoryRegistrationHandler = new FactoryRegistrationHandler()) {
@@ -202,7 +202,7 @@ public class FactoryRegistrationHandlerTest {
     }
 
     @RepeatedTest(DEFAULT_TEST_ITERATIONS)
-    public void testUnregisterOnClose() throws InterruptedException {
+    void testUnregisterOnClose() throws InterruptedException {
         final BundleContext ctx = osgi.bundleContext();
         final FactoryPreconditions preconditions = mock(FactoryPreconditions.class);
         final FactoryRegistrationHandler factoryRegistrationHandler = new FactoryRegistrationHandler();

--- a/src/test/java/org/apache/sling/resourceresolver/util/CustomMatchers.java
+++ b/src/test/java/org/apache/sling/resourceresolver/util/CustomMatchers.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.StringDescription;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Custom version of Hamcrest matchers that fix the generics to make them usable.
+ */
+public class CustomMatchers {
+
+
+    @SafeVarargs
+    @NotNull
+    public static <T> Matcher<T> allOf(Matcher<? extends T> first, Matcher<? extends T>... more) {
+        final List<Matcher<? extends T>> matchers = Stream.concat(Stream.of(first), Stream.of(more)).collect(Collectors.toList());
+        return new AllOfMatcher<>(matchers);
+    }
+
+    public static <T> Matcher<Iterable<? extends T>> hasItem(T item) {
+        return hasItem(Matchers.equalTo(item));
+    }
+
+    public static <T> Matcher<Iterable<? extends T>> hasItem(Matcher<? extends T> elementMatcher) {
+        return new HasItemMatcher<>(elementMatcher);
+    }
+
+
+    private static <T> Stream<? extends T> toStream(Iterable<? extends T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false);
+    };
+
+    private static class AllOfMatcher<T> extends TypeSafeDiagnosingMatcher<T> {
+        private final Collection<Matcher<? extends T>> matchers;
+
+        AllOfMatcher(Collection<Matcher<? extends T>> matchers) {
+            this.matchers = matchers;
+        }
+
+        @Override
+        protected boolean matchesSafely(T item, Description mismatchDescription) {
+            return matchers.stream()
+                    .filter(matcher -> !matcher.matches(item))
+                    .peek(matcher -> {
+                        mismatchDescription.appendDescriptionOf(matcher).appendText(" ");
+                        matcher.describeMismatch(item, mismatchDescription);
+                    })
+                    .findFirst()
+                    .isEmpty();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendList("(", " " + "and" + " ", ")", matchers);
+        }
+    }
+
+    private static class HasItemMatcher<T> extends TypeSafeDiagnosingMatcher<Iterable<? extends T>> {
+
+        private final Matcher<? extends T> elementMatcher;
+
+        public HasItemMatcher(Matcher<? extends T> elementMatcher) {
+            this.elementMatcher = elementMatcher;
+        }
+
+        @Override
+        protected boolean matchesSafely(Iterable<? extends T> iterable, Description mismatchDescription) {
+            if (toStream(iterable).limit(1).count() == 0) {
+                mismatchDescription.appendText("was empty");
+                return false;
+            }
+
+            if (toStream(iterable).anyMatch(elementMatcher::matches)) {
+                return true;
+            }
+
+            mismatchDescription.appendText(
+                    toStream(iterable)
+                            .map(item -> describeItemMismatch(elementMatcher, item))
+                            .collect(Collectors.joining(", ", "mismatches were: [", "]")));
+            return false;
+        }
+
+        @NotNull
+        private String describeItemMismatch(Matcher<? extends T> elementMatcher1, T item) {
+            final StringDescription desc = new StringDescription();
+            elementMatcher1.describeMismatch(item, desc);
+            return desc.toString();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("an iterable containing ").appendDescriptionOf(elementMatcher);
+        }
+    }
+}

--- a/src/test/java/org/apache/sling/resourceresolver/util/events/AbstractAwaitingListener.java
+++ b/src/test/java/org/apache/sling/resourceresolver/util/events/AbstractAwaitingListener.java
@@ -59,8 +59,6 @@ abstract class AbstractAwaitingListener implements ServiceListener, AutoCloseabl
     protected abstract boolean isMatchingServiceEvent(ServiceEvent serviceEvent);
 
     protected boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        // sleep a little to give other threads an opportunity to complete service (un)registrations
-        TimeUnit.MILLISECONDS.sleep(1);
         return latch.await(timeout, timeUnit);
     }
 

--- a/src/test/java/org/apache/sling/resourceresolver/util/events/AbstractAwaitingListener.java
+++ b/src/test/java/org/apache/sling/resourceresolver/util/events/AbstractAwaitingListener.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.util.events;
+
+import org.apache.sling.resourceresolver.util.events.ServiceEventUtil.ServiceEventDTO;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+abstract class AbstractAwaitingListener implements ServiceListener, AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractAwaitingListener.class);
+
+    private final BundleContext bundleContext;
+
+    private final CountDownLatch latch;
+
+    public AbstractAwaitingListener(BundleContext ctx, int count) {
+        this.bundleContext = ctx;
+        this.latch = new CountDownLatch(count);
+    }
+
+    protected final void startListening() {
+        this.bundleContext.addServiceListener(this);
+        LOG.info("addServiceListener({})", this);
+    }
+
+    @Override
+    public void serviceChanged(ServiceEvent event) {
+        final ServiceEventDTO eventDTO = ServiceEventDTO.create(event);
+        final boolean matchingServiceEvent = isMatchingServiceEvent(event);
+        LOG.info("serviceChanged({}, {}) => {} | {}", eventDTO.getEventType(), eventDTO.getClasses(), matchingServiceEvent, this);
+        if (matchingServiceEvent) {
+            latch.countDown();
+        }
+    }
+
+    protected abstract boolean isMatchingServiceEvent(ServiceEvent serviceEvent);
+
+    protected boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        // sleep a little to give other threads an opportunity to complete service (un)registrations
+        TimeUnit.MILLISECONDS.sleep(1);
+        return latch.await(timeout, timeUnit);
+    }
+
+    @Override
+    public void close() {
+        stopListening();
+    }
+
+    protected void stopListening() {
+        bundleContext.removeServiceListener(this);
+        LOG.info("removeServiceListener({})", this);
+    }
+
+}

--- a/src/test/java/org/apache/sling/resourceresolver/util/events/RecordingListener.java
+++ b/src/test/java/org/apache/sling/resourceresolver/util/events/RecordingListener.java
@@ -83,7 +83,8 @@ public class RecordingListener extends AbstractAwaitingListener {
         if (signalRegistration != null) {
             final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
             while (!serviceEventDTOMatcher.matches(serviceEvents) && System.nanoTime() < deadline) {
-                TimeUnit.MILLISECONDS.sleep(1);
+                // give other threads a chance
+                Thread.yield();
             }
             signalRegistration.unregister();
             if (!await(1, TimeUnit.SECONDS)) {

--- a/src/test/java/org/apache/sling/resourceresolver/util/events/RecordingListener.java
+++ b/src/test/java/org/apache/sling/resourceresolver/util/events/RecordingListener.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.util.events;
+
+import org.apache.sling.resourceresolver.util.events.ServiceEventUtil.ServiceEventDTO;
+import org.hamcrest.Matcher;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceRegistration;
+
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RecordingListener extends AbstractAwaitingListener {
+
+    private final Collection<ServiceEventDTO> serviceEvents = new ConcurrentLinkedQueue<ServiceEventDTO>();
+
+    private ServiceRegistration<RecordingListener> signalRegistration;
+
+    private final Predicate<ServiceEvent> recordingFilter;
+
+    public static RecordingListener of(BundleContext ctx) {
+        final RecordingListener recordingListener = new RecordingListener(ctx, serviceEvent -> true);
+        recordingListener.startListening();
+        return recordingListener;
+    }
+
+    public static RecordingListener of(BundleContext ctx, Predicate<ServiceEvent> recordingFilter) {
+        final RecordingListener recordingListener = new RecordingListener(ctx, recordingFilter);
+        recordingListener.startListening();
+        return recordingListener;
+    }
+
+    private RecordingListener(BundleContext ctx, Predicate<ServiceEvent> recordingFilter) {
+        super(ctx, 1);
+        this.recordingFilter = recordingFilter;
+        this.signalRegistration = ctx.registerService(RecordingListener.class, this,
+                new Hashtable<>(Map.of("::class::", RecordingListener.class)));
+    }
+
+    @Override
+    protected boolean isMatchingServiceEvent(ServiceEvent serviceEvent) {
+        return signalRegistration != null // is null when registering "this"
+                && serviceEvent.getServiceReference() == signalRegistration.getReference();
+    }
+
+    @Override
+    public void serviceChanged(ServiceEvent serviceEvent) {
+        super.serviceChanged(serviceEvent);
+        if (!isInternalEvent(serviceEvent) && recordingFilter.test(serviceEvent)) {
+            serviceEvents.add(ServiceEventDTO.create(serviceEvent));
+        }
+    }
+
+    private boolean isInternalEvent(ServiceEvent serviceEvent) {
+        return Objects.equals(serviceEvent.getServiceReference().getProperty("::class::"), RecordingListener.class);
+    }
+
+    public void assertRecorded(Matcher<? super Collection<? extends ServiceEventDTO>> serviceEventDTOMatcher) throws InterruptedException {
+        if (signalRegistration != null) {
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+            while (!serviceEventDTOMatcher.matches(serviceEvents) && System.nanoTime() < deadline) {
+                TimeUnit.MILLISECONDS.sleep(1);
+            }
+            signalRegistration.unregister();
+            if (!await(1, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Unregistration event not observed within 1 second.");
+            }
+            signalRegistration = null;
+            stopListening();
+        }
+
+        assertThat("Expected ServiceEvents", serviceEvents, serviceEventDTOMatcher);
+    }
+}

--- a/src/test/java/org/apache/sling/resourceresolver/util/events/ServiceEventUtil.java
+++ b/src/test/java/org/apache/sling/resourceresolver/util/events/ServiceEventUtil.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.util.events;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.osgi.framework.ServiceEvent;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ServiceEventUtil {
+
+    public static Matcher<ServiceEventDTO> registration(Class<?> clazz) {
+        return Matchers.equalTo(ServiceEventDTO.create(ServiceEvent.REGISTERED, clazz));
+    }
+
+    public static Matcher<ServiceEventDTO> unregistration(Class<?> clazz) {
+        return Matchers.equalTo(ServiceEventDTO.create(ServiceEvent.UNREGISTERING, clazz));
+    }
+
+    public static class ServiceEventDTO {
+
+        private static final String[] SERVICE_EVENT_TYPES = new String[9];
+        static {
+            SERVICE_EVENT_TYPES[ServiceEvent.REGISTERED] = "REGISTERED";
+            SERVICE_EVENT_TYPES[ServiceEvent.UNREGISTERING] = "UNREGISTERING";
+            SERVICE_EVENT_TYPES[ServiceEvent.MODIFIED] = "MODIFIED";
+            SERVICE_EVENT_TYPES[ServiceEvent.MODIFIED_ENDMATCH] = "MODIFIED_ENDMATCH";
+        }
+
+        private final int eventType;
+
+        private final Set<String> classNames;
+
+        private ServiceEventDTO(int eventType, Set<String> classNames) {
+            this.eventType = eventType;
+            this.classNames = Collections.unmodifiableSet(classNames);
+        }
+
+        public static ServiceEventDTO create(int eventType, Class<?>... classes) {
+            final Set<String> classNames = Stream.of(classes).map(Class::getName).collect(Collectors.toCollection(TreeSet::new));
+            return new ServiceEventDTO(eventType, classNames);
+        }
+
+        public static ServiceEventDTO create(ServiceEvent event) {
+            final int eventType = event.getType();
+            final Object objectClass = event.getServiceReference().getProperty("objectClass");
+            final Set<String> classNames;
+            if (objectClass instanceof String[]) {
+                classNames = new TreeSet<>(Arrays.asList((String[]) objectClass));
+            } else {
+                classNames = Collections.emptySet();
+            }
+            return new ServiceEventDTO(eventType, classNames);
+        }
+
+        public String getEventType() {
+            return SERVICE_EVENT_TYPES[eventType];
+        }
+
+        public Set<String> getClasses() {
+            return classNames;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ServiceEventDTO that = (ServiceEventDTO) o;
+            return eventType == that.eventType && Objects.equals(classNames, that.classNames);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(eventType, classNames);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("ServiceEvent(%s, %s)", getEventType(), classNames);
+        }
+    }
+}

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
- reworked synchronization from relying on worker queue to locks
- increased test coverage, particularly for concurrent scenarios
- switched to junit-platform to allow mixing junit4 and junit5 tests
- enabled parallel test execution for junit-platform