### PR TITLE
SLING-12222: INFO-level log not only query time but also # of resources (and rate) for sling:alias and sling:vanityPath

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -354,7 +354,7 @@ public class MapEntries implements
                 long initElapsed = System.nanoTime() - initStart;
                 long resourcesPerSecond = (vanityResourcesOnStartup.get() * TimeUnit.SECONDS.toNanos(1) / (initElapsed == 0 ? 1 : initElapsed));
                 log.info(
-                        "vanity path initialization - end, processed {} resources with sling:vanityPath properties in {}ms (~{} resource/s)",
+                        "vanity path initialization - completed, processed {} resources with sling:vanityPath properties in {}ms (~{} resource/s)",
                         vanityResourcesOnStartup.get(), TimeUnit.NANOSECONDS.toMillis(initElapsed), resourcesPerSecond);
             } catch (LoginException ex) {
                 log.error("Vanity path init failed", ex);
@@ -1174,8 +1174,8 @@ public class MapEntries implements
         }
         long processElapsed = System.nanoTime() - processStart;
         long resourcePerSecond = (count * TimeUnit.SECONDS.toNanos(1) / (processElapsed == 0 ? 1 : processElapsed));
-        log.info("alias initialization - end, processed {} resources with sling:alias properties in {}ms (~{} resource/s)", count,
-                TimeUnit.NANOSECONDS.toMillis(processElapsed), resourcePerSecond);
+        log.info("alias initialization - completed, processed {} resources with sling:alias properties in {}ms (~{} resource/s)",
+                count, TimeUnit.NANOSECONDS.toMillis(processElapsed), resourcePerSecond);
 
         this.aliasResourcesOnStartup.set(count);
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -352,7 +352,10 @@ public class MapEntries implements
                 drainQueue(resourceChangeQueue);
 
                 long initElapsed = System.nanoTime() - initStart;
-                log.info("vanity path initialization - end, elapsed {}ms", TimeUnit.NANOSECONDS.toMillis(initElapsed));
+                long resourcesPerSecond = (vanityResourcesOnStartup.get() * TimeUnit.SECONDS.toNanos(1) / (initElapsed == 0 ? 1 : initElapsed));
+                log.info(
+                        "vanity path initialization - end, processed {} resources with sling:vanityPath properties in {}ms (~{} resource/s)",
+                        vanityResourcesOnStartup.get(), TimeUnit.NANOSECONDS.toMillis(initElapsed), resourcesPerSecond);
             } catch (LoginException ex) {
                 log.error("Vanity path init failed", ex);
             } finally {
@@ -1163,6 +1166,7 @@ public class MapEntries implements
             it = queryUnpaged("alias", baseQueryString);
         }
 
+        log.debug("alias initialization - start");
         long count = 0;
         long processStart = System.nanoTime();
         while (it.hasNext()) {
@@ -1170,7 +1174,9 @@ public class MapEntries implements
             loadAlias(it.next(), map);
         }
         long processElapsed = System.nanoTime() - processStart;
-        log.debug("processed {} resources with sling:alias properties in {}ms", count, TimeUnit.NANOSECONDS.toMillis(processElapsed));
+        long resourcePerSecond = (count * TimeUnit.SECONDS.toNanos(1) / (processElapsed == 0 ? 1 : processElapsed));
+        log.info("alias initialization - end, processed {} resources with sling:alias properties in {}ms (~{} resource/s)", count,
+                TimeUnit.NANOSECONDS.toMillis(processElapsed), resourcePerSecond);
 
         this.aliasResourcesOnStartup.set(count);
 


### PR DESCRIPTION
sample output:

~~~
09.01.2024 17:47:51.581 *INFO* [ResourceResolverFactory registration] org.apache.sling.resourceresolver.impl.mapping.MapEntries alias initialization - end, processed 134066 resources with sling:alias properties in 34040ms (~3938 resource/s)
09.01.2024 17:47:51.654 *INFO* [VanityPathInitializer] org.apache.sling.resourceresolver.impl.mapping.MapEntries vanity path initialization - end, processed 47 resources with sling:vanityPath properties in 43ms (~1083 resource/s)
~~~