### PR TITLE
SLING-12412: ResourceResolver: add test coverage for empty aliases, blank aliases, and invalid aliases

### DIFF
--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PathGeneratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PathGeneratorTest.java
@@ -103,6 +103,20 @@ public class PathGeneratorTest {
         assertThat(paths, Matchers.hasItems("/alias1/bar", "/alias2/bar", "/foo/bar"));
     }
 
+    // test for SLING-12399
+    @Test
+    public void subPathWithMultipleIncludingEmptyAliases() {
+        
+        PathGenerator builder = new PathGenerator();
+        builder.insertSegment(emptyList(), "bar");
+        builder.insertSegment(asList("", "alias1"), "foo");
+        
+        List<String> paths = builder.generatePaths();
+        
+        assertThat(paths, Matchers.hasSize(2));
+        assertThat(paths, Matchers.hasItems("/alias1/bar", "/foo/bar"));
+    }
+
     @Test
     public void subPathWithComplexAliasesSetup() {
         


### PR DESCRIPTION
This just increases test coverage, with no assumptions whether the observed behavior is actually correct.
