### PR TITLE
Resource Resolver: refactor MapEntries - improve MapIterator test coverage

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -721,7 +721,7 @@ public class MapEntries implements
             key = requestPath.substring(secondIndex);
         }
 
-        return new MapEntryIterator(key, resolveMapsMap.get(GLOBAL_LIST_KEY).iterator(),
+        return new MapEntryIterator(key, resolveMapsMap.get(GLOBAL_LIST_KEY),
                 this::getCurrentMapEntryForVanityPath, this.factory.hasVanityPathPrecedence());
     }
 
@@ -1702,7 +1702,7 @@ public class MapEntries implements
         return l == null ? Collections.emptyIterator() : l.iterator();
     }
 
-    private final class MapEntryIterator implements Iterator<MapEntry> {
+    static final class MapEntryIterator implements Iterator<MapEntry> {
 
         private String key;
 
@@ -1717,11 +1717,11 @@ public class MapEntries implements
         private boolean vanityPathPrecedence;
         private final Function<String, Iterator<MapEntry>> getCurrentMapEntryIteratorForVanityPath;
 
-        public MapEntryIterator(final String startKey, @NotNull final Iterator<MapEntry> globalListIterator,
+        public MapEntryIterator(final String startKey, @NotNull final List<MapEntry> globalList,
                                 final Function<String, Iterator<MapEntry>> getCurrentMapEntryIteratorForVanityPath,
                                 final boolean vanityPathPrecedence) {
             this.key = startKey;
-            this.globalListIterator = globalListIterator;
+            this.globalListIterator = globalList.iterator();
             this.vanityPathPrecedence = vanityPathPrecedence;
             this.getCurrentMapEntryIteratorForVanityPath = getCurrentMapEntryIteratorForVanityPath;
             this.seek();

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -1692,7 +1692,7 @@ public class MapEntries implements
 
     // return vanity path entry iterator from cache when complete and ready, otherwise from
     // regular lockup
-    public @Nullable List<MapEntry> getCurrentMapEntryForVanityPath(@NotNull final String key) {
+    public @Nullable List<MapEntry> getCurrentMapEntryForVanityPath(final String key) {
         if (this.isAllVanityPathEntriesCached() && this.vanityPathsProcessed.get()) {
             return this.resolveMapsMap.get(key);
         } else {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -73,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class MapEntries implements
@@ -720,7 +721,8 @@ public class MapEntries implements
             key = requestPath.substring(secondIndex);
         }
 
-        return new MapEntryIterator(key, resolveMapsMap, this.factory.hasVanityPathPrecedence());
+        return new MapEntryIterator(key, resolveMapsMap.get(GLOBAL_LIST_KEY).iterator(),
+                this::getCurrentMapEntryForVanityPath, this.factory.hasVanityPathPrecedence());
     }
 
     @Override
@@ -731,7 +733,7 @@ public class MapEntries implements
     public boolean isOptimizeAliasResolutionEnabled() {
         return this.useOptimizeAliasResolution;
     }
-    
+
     @Override
     public @NotNull Map<String, Collection<String>> getAliasMap(final String parentPath) {
         Map<String, Collection<String>> aliasMapForParent = aliasMapsMap.get(parentPath);
@@ -1686,12 +1688,21 @@ public class MapEntries implements
                 log.error("A problem occured during initialization of optimize alias resolution. Optimize alias resolution is disabled. Check the logs for the reported problem.", e);
             }
         }
+    }
 
+    // return vanity path entry iterator from cache when complete and ready, otherwise from
+    // regular lockup
+    public @NotNull Iterator<MapEntry> getCurrentMapEntryForVanityPath(final String key) {
+        List<MapEntry> l;
+        if (this.isAllVanityPathEntriesCached() && this.vanityPathsProcessed.get()) {
+            l = this.resolveMapsMap.get(key);
+        } else {
+            l = this.getMapEntryList(key);
+        }
+        return l == null ? Collections.emptyIterator() : l.iterator();
     }
 
     private final class MapEntryIterator implements Iterator<MapEntry> {
-
-        private final Map<String, List<MapEntry>> resolveMapsMap;
 
         private String key;
 
@@ -1704,12 +1715,15 @@ public class MapEntries implements
         private MapEntry nextSpecial;
 
         private boolean vanityPathPrecedence;
+        private final Function<String, Iterator<MapEntry>> getCurrentMapEntryIteratorForVanityPath;
 
-        public MapEntryIterator(final String startKey, final Map<String, List<MapEntry>> resolveMapsMap, final boolean vanityPathPrecedence) {
+        public MapEntryIterator(final String startKey, @NotNull final Iterator<MapEntry> globalListIterator,
+                                final Function<String, Iterator<MapEntry>> getCurrentMapEntryIteratorForVanityPath,
+                                final boolean vanityPathPrecedence) {
             this.key = startKey;
-            this.resolveMapsMap = resolveMapsMap;
-            this.globalListIterator = this.resolveMapsMap.get(GLOBAL_LIST_KEY).iterator();
+            this.globalListIterator = globalListIterator;
             this.vanityPathPrecedence = vanityPathPrecedence;
+            this.getCurrentMapEntryIteratorForVanityPath = getCurrentMapEntryIteratorForVanityPath;
             this.seek();
         }
 
@@ -1758,15 +1772,8 @@ public class MapEntries implements
                         key = key.substring(0, lastDotPos);
                     }
 
-                    final List<MapEntry> special;
-                    if (MapEntries.this.isAllVanityPathEntriesCached() && MapEntries.this.vanityPathsProcessed.get()) {
-                        special = this.resolveMapsMap.get(key);
-                    } else {
-                        special = MapEntries.this.getMapEntryList(key); 
-                    }
-                    if (special != null) {
-                        specialIterator = special.iterator();
-                    }
+                    this.specialIterator = this.getCurrentMapEntryIteratorForVanityPath.apply(this.key);
+
                     // recurse to the parent
                     if (key.length() > 1) {
                         final int lastSlash = key.lastIndexOf("/");
@@ -1786,7 +1793,7 @@ public class MapEntries implements
             if (this.nextSpecial == null) {
                 this.next = this.nextGlobal;
                 this.nextGlobal = null;
-            } else if (!this.vanityPathPrecedence){
+            } else if (!vanityPathPrecedence) {
                 if (this.nextGlobal == null) {
                     this.next = this.nextSpecial;
                     this.nextSpecial = null;
@@ -1794,7 +1801,7 @@ public class MapEntries implements
                     this.next = this.nextGlobal;
                     this.nextGlobal = null;
 
-                }else {
+                } else {
                     this.next = this.nextSpecial;
                     this.nextSpecial = null;
                 }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -1692,7 +1692,7 @@ public class MapEntries implements
 
     // return vanity path entry iterator from cache when complete and ready, otherwise from
     // regular lockup
-    public @Nullable List<MapEntry> getCurrentMapEntryForVanityPath(final String key) {
+    public @Nullable List<MapEntry> getCurrentMapEntryForVanityPath(@NotNull final String key) {
         if (this.isAllVanityPathEntriesCached() && this.vanityPathsProcessed.get()) {
             return this.resolveMapsMap.get(key);
         } else {

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
@@ -31,56 +31,40 @@ import static org.junit.Assert.assertThrows;
 
 public class MapEntryIteratorTest {
 
-    private MapEntries.MapEntryIterator empty = new MapEntries.MapEntryIterator(null, List.of(), key -> Collections.emptyList(), true);
+    private final MapEntries.MapEntryIterator empty =
+            new MapEntries.MapEntryIterator(null, List.of(), key -> Collections.emptyList(), true);
 
-    private MapEntry xyz =
+    private final MapEntry xyz =
             new MapEntry("/xyz", -1, false, -1, "/foo", "/bar");
 
-    private MapEntry xyzAbc =
-            new MapEntry("/xyz/def/abc", -1, false, -1, "/qux");
-
-    private MapEntry global =
+    private final MapEntry global =
             new MapEntry("/foo/global/long", -1, false, -1, "bla");
 
-    private Map<String, List<MapEntry>> xyzMap = Map.of("/xyz", List.of(xyz));
-
-    private Map<String, List<MapEntry>> xyzAbcMap = Map.of("/xyz", List.of(xyz), "/xyz/def/abc", List.of(xyzAbc));
-
-    private MapEntries.MapEntryIterator vpOnlyIterator =
-            new MapEntries.MapEntryIterator("/xyz",
-                    List.of(),
-                    key -> List.of(xyz),
-                    true);
-
-    private MapEntries.MapEntryIterator vpHierarchyOnlyIterator =
-            new MapEntries.MapEntryIterator("/xyz/def/abc",
-                    List.of(),
-                    key -> xyzAbcMap.get(key),
-                    true);
-
-    private MapEntries.MapEntryIterator noVpIterator =
-            new MapEntries.MapEntryIterator("/xyz",
-                    List.of(xyz),
-                    key -> Collections.emptyList(),
-                    true);
-
+    private final Map<String, List<MapEntry>> xyzMap =
+            Map.of("/xyz", List.of(xyz));
 
     @Test
     public void testExhausted() {
         assertFalse(empty.hasNext());
         assertThrows(NoSuchElementException.class,
-                () -> empty.next());
+                empty::next);
     }
 
     @Test
     public void testRemove() {
         assertFalse(empty.hasNext());
         assertThrows(UnsupportedOperationException.class,
-                () -> empty.remove());
+                empty::remove);
     }
 
     @Test
     public void testOnlyOneEntry() {
+        MapEntries.MapEntryIterator noVpIterator =
+                new MapEntries.MapEntryIterator("/xyz",
+                        List.of(xyz),
+                        key -> Collections.emptyList(),
+                        true);
+
         MapEntry first = noVpIterator.next();
         assertFalse(noVpIterator.hasNext());
         assertEquals("^/xyz", first.getPattern());
@@ -91,6 +75,12 @@ public class MapEntryIteratorTest {
 
     @Test
     public void testOnlyOneVanityPath() {
+        MapEntries.MapEntryIterator vpOnlyIterator =
+                new MapEntries.MapEntryIterator("/xyz",
+                        List.of(),
+                        key -> List.of(xyz),
+                        true);
+
         MapEntry first = vpOnlyIterator.next();
         assertFalse(vpOnlyIterator.hasNext());
         assertEquals("^/xyz", first.getPattern());
@@ -101,6 +91,18 @@ public class MapEntryIteratorTest {
 
     @Test
     public void testHierarchyVanityPath() {
+        MapEntry xyzAbc =
+                new MapEntry("/xyz/def/abc", -1, false, -1, "/qux");
+
+        Map<String, List<MapEntry>> xyzAbcMap =
+                Map.of("/xyz", List.of(xyz), "/xyz/def/abc", List.of(xyzAbc));
+
+        MapEntries.MapEntryIterator vpHierarchyOnlyIterator =
+                new MapEntries.MapEntryIterator("/xyz/def/abc",
+                        List.of(),
+                        xyzAbcMap::get,
+                        true);
+
         MapEntry first = vpHierarchyOnlyIterator.next();
         MapEntry second = vpHierarchyOnlyIterator.next();
         assertFalse(vpHierarchyOnlyIterator.hasNext());
@@ -117,7 +119,7 @@ public class MapEntryIteratorTest {
     public void testBothIteratorVpFirst() {
         MapEntries.MapEntryIterator bothIteratorVpFirst = new MapEntries.MapEntryIterator("/xyz",
                 List.of(global),
-                key -> xyzMap.get(key),
+                xyzMap::get,
                 true
         );
 
@@ -137,7 +139,7 @@ public class MapEntryIteratorTest {
     public void testBothIteratorVpDefault() {
         MapEntries.MapEntryIterator bothIteratorVpDefault = new MapEntries.MapEntryIterator("/xyz",
                 List.of(global),
-                key -> xyzMap.get(key),
+                xyzMap::get,
                 false
         );
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
@@ -40,7 +40,7 @@ public class MapEntryIteratorTest {
             new MapEntry("/xyz/def/abc", -1, false, -1, "/qux");
 
     private MapEntry global =
-            new MapEntry("/foo/global", -1, false, -1, "bla");
+            new MapEntry("/foo/global/long", -1, false, -1, "bla");
 
     private Map<String, List<MapEntry>> xyzMap = Map.of("/xyz", List.of(xyz));
 
@@ -64,17 +64,6 @@ public class MapEntryIteratorTest {
                     key -> Collections.emptyList(),
                     true);
 
-    private MapEntries.MapEntryIterator bothIteratorVpFirst = new MapEntries.MapEntryIterator("/xyz",
-            List.of(global),
-            key ->  xyzMap.get(key),
-            true
-            );
-
-    private MapEntries.MapEntryIterator bothIteratorVpLast = new MapEntries.MapEntryIterator("/xyz",
-            List.of(global),
-            key ->  xyzMap.get(key),
-            false
-    );
 
     @Test
     public void testExhausted() {
@@ -126,6 +115,12 @@ public class MapEntryIteratorTest {
 
     @Test
     public void testBothIteratorVpFirst() {
+        MapEntries.MapEntryIterator bothIteratorVpFirst = new MapEntries.MapEntryIterator("/xyz",
+                List.of(global),
+                key -> xyzMap.get(key),
+                true
+        );
+
         MapEntry first = bothIteratorVpFirst.next();
         MapEntry second = bothIteratorVpFirst.next();
         assertFalse(bothIteratorVpFirst.hasNext());
@@ -133,22 +128,29 @@ public class MapEntryIteratorTest {
         assertEquals(2, first.getRedirect().length);
         assertEquals("/foo", first.getRedirect()[0]);
         assertEquals("/bar", first.getRedirect()[1]);
-        assertEquals("^/foo/global", second.getPattern());
+        assertEquals("^/foo/global/long", second.getPattern());
         assertEquals(1, second.getRedirect().length);
         assertEquals("bla", second.getRedirect()[0]);
     }
 
     @Test
-    public void testBothIteratorVpLast() {
-        MapEntry second = bothIteratorVpLast.next();
-        MapEntry first = bothIteratorVpLast.next();
-        assertFalse(bothIteratorVpLast.hasNext());
-        assertEquals("^/xyz", first.getPattern());
-        assertEquals(2, first.getRedirect().length);
-        assertEquals("/foo", first.getRedirect()[0]);
-        assertEquals("/bar", first.getRedirect()[1]);
-        assertEquals("^/foo/global", second.getPattern());
-        assertEquals(1, second.getRedirect().length);
-        assertEquals("bla", second.getRedirect()[0]);
+    public void testBothIteratorVpDefault() {
+        MapEntries.MapEntryIterator bothIteratorVpDefault = new MapEntries.MapEntryIterator("/xyz",
+                List.of(global),
+                key -> xyzMap.get(key),
+                false
+        );
+
+        MapEntry first = bothIteratorVpDefault.next();
+        MapEntry second = bothIteratorVpDefault.next();
+        assertFalse(bothIteratorVpDefault.hasNext());
+
+        assertEquals("^/foo/global/long", first.getPattern());
+        assertEquals(1, first.getRedirect().length);
+        assertEquals("bla", first.getRedirect()[0]);
+        assertEquals("^/xyz", second.getPattern());
+        assertEquals(2, second.getRedirect().length);
+        assertEquals("/foo", second.getRedirect()[0]);
+        assertEquals("/bar", second.getRedirect()[1]);
     }
 }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.impl.mapping;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class MapEntryIteratorTest {
+
+    private MapEntries.MapEntryIterator empty = new MapEntries.MapEntryIterator(null, List.of(), key -> Collections.emptyIterator(), true);
+
+    private MapEntry xyz =
+            new MapEntry("/xyz", -1, false, -1, "/foo", "/bar");
+
+    private MapEntry xyzAbc =
+            new MapEntry("/xyz/def/abc", -1, false, -1, "/qux");
+
+    private MapEntry global =
+            new MapEntry("/foo/global", -1, false, -1, "bla");
+
+    private Map<String, List<MapEntry>> xyzMap = Map.of("/xyz", List.of(xyz));
+
+    private Map<String, List<MapEntry>> xyzAbcMap = Map.of("/xyz", List.of(xyz), "/xyz/def/abc", List.of(xyzAbc));
+
+    private MapEntries.MapEntryIterator vpOnlyIterator =
+            new MapEntries.MapEntryIterator("/xyz",
+                    List.of(),
+                    key -> List.of(xyz).iterator(),
+                    true);
+
+    private MapEntries.MapEntryIterator vpHierarchyOnlyIterator =
+            new MapEntries.MapEntryIterator("/xyz/def/abc",
+                    List.of(),
+                    key -> xyzAbcMap.get(key) == null ? Collections.emptyIterator() : xyzAbcMap.get(key).iterator(),
+                    true);
+
+    private MapEntries.MapEntryIterator noVpIterator =
+            new MapEntries.MapEntryIterator("/xyz",
+                    List.of(xyz),
+                    key -> Collections.emptyIterator(),
+                    true);
+
+    private MapEntries.MapEntryIterator bothIteratorVpFirst = new MapEntries.MapEntryIterator("/xyz",
+            List.of(global),
+            key ->  xyzMap.get(key) == null ? Collections.emptyIterator() : xyzMap.get(key).iterator(),
+            true
+            );
+
+    private MapEntries.MapEntryIterator bothIteratorVpLast = new MapEntries.MapEntryIterator("/xyz",
+            List.of(global),
+            key ->  xyzMap.get(key) == null ? Collections.emptyIterator() : xyzMap.get(key).iterator(),
+            false
+    );
+
+    @Test(expected = NoSuchElementException.class)
+    public void testExhausted() {
+        assertFalse(empty.hasNext());
+        empty.next();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemove() {
+        assertFalse(empty.hasNext());
+        empty.remove();
+    }
+
+    @Test
+    public void testOnlyOneEntry() {
+        MapEntry first = noVpIterator.next();
+        assertFalse(noVpIterator.hasNext());
+        assertEquals("^/xyz", first.getPattern());
+        assertEquals(2, first.getRedirect().length);
+        assertEquals("/foo", first.getRedirect()[0]);
+        assertEquals("/bar", first.getRedirect()[1]);
+    }
+
+    @Test
+    public void testOnlyOneVanityPath() {
+        MapEntry first = vpOnlyIterator.next();
+        assertFalse(vpOnlyIterator.hasNext());
+        assertEquals("^/xyz", first.getPattern());
+        assertEquals(2, first.getRedirect().length);
+        assertEquals("/foo", first.getRedirect()[0]);
+        assertEquals("/bar", first.getRedirect()[1]);
+    }
+
+    @Test
+    public void testHierarchyVanityPath() {
+        MapEntry first = vpHierarchyOnlyIterator.next();
+        MapEntry second = vpHierarchyOnlyIterator.next();
+        assertFalse(vpHierarchyOnlyIterator.hasNext());
+        assertEquals("^/xyz/def/abc", first.getPattern());
+        assertEquals(1, first.getRedirect().length);
+        assertEquals("/qux", first.getRedirect()[0]);
+        assertEquals("^/xyz", second.getPattern());
+        assertEquals(2, second.getRedirect().length);
+        assertEquals("/foo", second.getRedirect()[0]);
+        assertEquals("/bar", second.getRedirect()[1]);
+    }
+
+    @Test
+    public void testBothIteratorVpFirst() {
+        MapEntry first = bothIteratorVpFirst.next();
+        MapEntry second = bothIteratorVpFirst.next();
+        assertFalse(bothIteratorVpFirst.hasNext());
+        assertEquals("^/xyz", first.getPattern());
+        assertEquals(2, first.getRedirect().length);
+        assertEquals("/foo", first.getRedirect()[0]);
+        assertEquals("/bar", first.getRedirect()[1]);
+        assertEquals("^/foo/global", second.getPattern());
+        assertEquals(1, second.getRedirect().length);
+        assertEquals("bla", second.getRedirect()[0]);
+    }
+
+    @Test
+    public void testBothIteratorVpLast() {
+        MapEntry second = bothIteratorVpLast.next();
+        MapEntry first = bothIteratorVpLast.next();
+        assertFalse(bothIteratorVpLast.hasNext());
+        assertEquals("^/xyz", first.getPattern());
+        assertEquals(2, first.getRedirect().length);
+        assertEquals("/foo", first.getRedirect()[0]);
+        assertEquals("/bar", first.getRedirect()[1]);
+        assertEquals("^/foo/global", second.getPattern());
+        assertEquals(1, second.getRedirect().length);
+        assertEquals("bla", second.getRedirect()[0]);
+    }
+}

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
@@ -27,6 +27,7 @@ import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 public class MapEntryIteratorTest {
 
@@ -75,16 +76,18 @@ public class MapEntryIteratorTest {
             false
     );
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testExhausted() {
         assertFalse(empty.hasNext());
-        empty.next();
+        assertThrows(NoSuchElementException.class,
+                () -> empty.next());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRemove() {
         assertFalse(empty.hasNext());
-        empty.remove();
+        assertThrows(UnsupportedOperationException.class,
+                () -> empty.remove());
     }
 
     @Test

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntryIteratorTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertFalse;
 
 public class MapEntryIteratorTest {
 
-    private MapEntries.MapEntryIterator empty = new MapEntries.MapEntryIterator(null, List.of(), key -> Collections.emptyIterator(), true);
+    private MapEntries.MapEntryIterator empty = new MapEntries.MapEntryIterator(null, List.of(), key -> Collections.emptyList(), true);
 
     private MapEntry xyz =
             new MapEntry("/xyz", -1, false, -1, "/foo", "/bar");
@@ -48,30 +48,30 @@ public class MapEntryIteratorTest {
     private MapEntries.MapEntryIterator vpOnlyIterator =
             new MapEntries.MapEntryIterator("/xyz",
                     List.of(),
-                    key -> List.of(xyz).iterator(),
+                    key -> List.of(xyz),
                     true);
 
     private MapEntries.MapEntryIterator vpHierarchyOnlyIterator =
             new MapEntries.MapEntryIterator("/xyz/def/abc",
                     List.of(),
-                    key -> xyzAbcMap.get(key) == null ? Collections.emptyIterator() : xyzAbcMap.get(key).iterator(),
+                    key -> xyzAbcMap.get(key),
                     true);
 
     private MapEntries.MapEntryIterator noVpIterator =
             new MapEntries.MapEntryIterator("/xyz",
                     List.of(xyz),
-                    key -> Collections.emptyIterator(),
+                    key -> Collections.emptyList(),
                     true);
 
     private MapEntries.MapEntryIterator bothIteratorVpFirst = new MapEntries.MapEntryIterator("/xyz",
             List.of(global),
-            key ->  xyzMap.get(key) == null ? Collections.emptyIterator() : xyzMap.get(key).iterator(),
+            key ->  xyzMap.get(key),
             true
             );
 
     private MapEntries.MapEntryIterator bothIteratorVpLast = new MapEntries.MapEntryIterator("/xyz",
             List.of(global),
-            key ->  xyzMap.get(key) == null ? Collections.emptyIterator() : xyzMap.get(key).iterator(),
+            key ->  xyzMap.get(key),
             false
     );
 


### PR DESCRIPTION
1. Untangle MapIterator from MapEntries for better testability from unit tests
2. Add unit tests