### PR TITLE
SLING-12632: move all (only) vanity path related code in a single place

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -290,112 +290,6 @@ public class MapEntries implements
         }
     }
 
-    /**
-     * Actual vanity paths initializer. Guards itself against concurrent use by
-     * using a ReentrantLock. Does nothing if the resource resolver has already
-     * been null-ed.
-     *
-     * @throws IOException in case of problems
-     */
-    protected void initializeVanityPaths() throws IOException {
-        this.initializing.lock();
-        try {
-            if (this.factory.isVanityPathEnabled()) {
-                this.vanityBloomFilter = createVanityBloomFilter();
-                VanityPathInitializer vpi = new VanityPathInitializer(this.factory);
-                if (this.factory.isVanityPathCacheInitInBackground()) {
-                    this.log.debug("bg init starting");
-                    Thread vpinit = new Thread(vpi, "VanityPathInitializer");
-                    vpinit.start();
-                } else {
-                    vpi.run();
-                }
-            }
-        } finally {
-            this.initializing.unlock();
-        }
-    }
-
-    private class VanityPathInitializer implements Runnable {
-
-        private int SIZELIMIT = 10000;
-
-        private MapConfigurationProvider factory;
-
-        public VanityPathInitializer(MapConfigurationProvider factory) {
-            this.factory = factory;
-        }
-
-        @Override
-        public void run() {
-            try {
-                temporaryResolveMapsMap = Collections.synchronizedMap(new LRUMap<>(SIZELIMIT));
-                execute();
-            } catch (Throwable t) {
-                log.error("vanity path initializer thread terminated with a throwable", t);
-            }
-        }
-
-        private void drainQueue(List<Map.Entry<String, ResourceChange.ChangeType>> queue) {
-            final AtomicBoolean resolverRefreshed = new AtomicBoolean(false);
-
-            // send the change event only once
-            boolean sendEvent = false;
-
-            // the config needs to be reloaded only once
-            final AtomicBoolean hasReloadedConfig = new AtomicBoolean(false);
-
-            while (!queue.isEmpty()) {
-                Map.Entry<String, ResourceChange.ChangeType> entry = queue.remove(0);
-                final ResourceChange.ChangeType type = entry.getValue();
-                final String path = entry.getKey();
-
-                log.trace("drain type={}, path={}", type, path);
-                boolean changed = handleResourceChange(type, path, resolverRefreshed, hasReloadedConfig);
-
-                if (changed) {
-                    sendEvent = true;
-                }
-            }
-
-            if (sendEvent) {
-                sendChangeEvent();
-            }
-        }
-
-        private void execute() {
-            try (ResourceResolver resolver = factory
-                    .getServiceResourceResolver(factory.getServiceUserAuthenticationInfo("mapping"))) {
-
-                long initStart = System.nanoTime();
-                log.debug("vanity path initialization - start");
-
-                vanityTargets = loadVanityPaths(resolver);
-
-                // process pending event
-                drainQueue(resourceChangeQueue);
-
-                vanityPathsProcessed.set(true);
-
-                // drain once more in case more events have arrived
-                drainQueue(resourceChangeQueue);
-
-                long initElapsed = System.nanoTime() - initStart;
-                long resourcesPerSecond = (vanityResourcesOnStartup.get() * TimeUnit.SECONDS.toNanos(1) / (initElapsed == 0 ? 1 : initElapsed));
-
-                log.info(
-                        "vanity path initialization - completed, processed {} resources with sling:vanityPath properties in {}ms (~{} resource/s)",
-                        vanityResourcesOnStartup.get(), TimeUnit.NANOSECONDS.toMillis(initElapsed), resourcesPerSecond);
-            } catch (LoginException ex) {
-                log.error("Vanity path init failed", ex);
-            } finally {
-                log.debug("dropping temporary resolver map - {}/{} entries, {} hits, {} misses", temporaryResolveMapsMap.size(),
-                        SIZELIMIT, temporaryResolveMapsMapHits.get(), temporaryResolveMapsMapMisses.get());
-                temporaryResolveMapsMap = null;
-            }
-        }
-    }
-
     private boolean addResource(final String path, final AtomicBoolean resolverRefreshed) {
         this.initializing.lock();
 
@@ -540,15 +434,6 @@ public class MapEntries implements
         }
     }
 
-    private boolean removeVanityPath(final String path) {
-        this.initializing.lock();
-        try {
-            return doRemoveVanity(path);
-        } finally {
-            this.initializing.unlock();
-        }
-    }
-
     /**
      * Update the configuration.
      * Does no locking and does not send an event at the end
@@ -566,40 +451,6 @@ public class MapEntries implements
         Collections.sort(globalResolveMap);
         resolveMapsMap.put(GLOBAL_LIST_KEY, globalResolveMap);
         this.mapMaps = Collections.unmodifiableSet(new TreeSet<>(newMapMaps.values()));
-    }
-
-    private boolean doAddVanity(final Resource resource) {
-        log.debug("doAddVanity getting {}", resource.getPath());
-
-        boolean updateTheCache = isAllVanityPathEntriesCached() || vanityCounter.longValue() < this.factory.getMaxCachedVanityPathEntries();
-        return null != loadVanityPath(resource, resolveMapsMap, vanityTargets, updateTheCache, true);
-    }
-
-    private boolean doRemoveVanity(final String path) {
-        final String actualContentPath = getActualContentPath(path);
-        final List <String> l = vanityTargets.remove(actualContentPath);
-        if (l != null){
-            for (final String s : l){
-                final List<MapEntry> entries = this.resolveMapsMap.get(s);
-                if (entries!= null) {
-                    for (final Iterator<MapEntry> iterator =entries.iterator(); iterator.hasNext(); ) {
-                        final MapEntry entry = iterator.next();
-                        final String redirect = getMapEntryRedirect(entry);
-                        if (redirect != null && redirect.equals(actualContentPath)) {
-                            iterator.remove();
-                        }
-                    }
-                }
-                if (entries!= null && entries.isEmpty()) {
-                    this.resolveMapsMap.remove(s);
-                }
-            }
-            if (vanityCounter.longValue() > 0) {
-                vanityCounter.addAndGet(-2);
-            }
-            return true;
-        }
-        return false;
     }
 
     private boolean doAddAlias(final Resource resource) {
@@ -747,68 +598,6 @@ public class MapEntries implements
     private static final List<MapEntry> NO_MAP_ENTRIES = Collections.emptyList();
 
     /**
-     * get the MapEntry list containing all the nodes having a specific vanityPath
-     */
-    private List<MapEntry> getMapEntryList(String vanityPath) {
-        List<MapEntry> mapEntries = null;
-
-        boolean initFinished = vanityPathsProcessed.get();
-        boolean probablyPresent = false;
-
-        if (initFinished) {
-            // total number of lookups after init (and when cache not complete)
-            long current = this.vanityPathLookups.incrementAndGet();
-            if (current >= Long.MAX_VALUE - 100000) {
-                // reset counters when we get close the limit
-                this.vanityPathLookups.set(1);
-                this.vanityPathBloomNegatives.set(0);
-                this.vanityPathBloomFalsePositives.set(0);
-                log.info("Vanity Path metrics reset to 0");
-            }
-
-            // init is done - check the bloom filter
-            probablyPresent = BloomFilterUtils.probablyContains(vanityBloomFilter, vanityPath);
-            log.trace("bloom filter lookup for {} -> {}", vanityPath, probablyPresent);
-
-            if (!probablyPresent) {
-                // filtered by Bloom filter
-                this.vanityPathBloomNegatives.incrementAndGet();
-            }
-        }
-
-        if (!initFinished || probablyPresent) {
-
-            mapEntries = this.resolveMapsMap.get(vanityPath);
-
-            if (mapEntries == null) {
-                if (!initFinished && temporaryResolveMapsMap != null) {
-                    mapEntries = temporaryResolveMapsMap.get(vanityPath);
-                    if (mapEntries != null) {
-                        temporaryResolveMapsMapHits.incrementAndGet();
-                        log.trace("getMapEntryList: using temp map entries for {} -> {}", vanityPath, mapEntries);
-                    } else {
-                        temporaryResolveMapsMapMisses.incrementAndGet();
-                    }
-                }
-                if (mapEntries == null) {
-                    Map<String, List<MapEntry>> mapEntry = getVanityPaths(vanityPath);
-                    mapEntries = mapEntry.get(vanityPath);
-                    if (!initFinished && temporaryResolveMapsMap != null) {
-                        log.trace("getMapEntryList: caching map entries for {} -> {}", vanityPath, mapEntries);
-                        temporaryResolveMapsMap.put(vanityPath, mapEntries == null ? NO_MAP_ENTRIES : mapEntries);
-                    }
-                }
-            }
-            if (mapEntries == null && probablyPresent) {
-                // Bloom filter had a false positive
-                this.vanityPathBloomFalsePositives.incrementAndGet();
-            }
-        }
-
-        return mapEntries == NO_MAP_ENTRIES ? null : mapEntries;
-    }
-
-    /**
      * Refresh the resource resolver if not already done
      * @param resolverRefreshed Boolean flag containing the state if the resolver
      *                          has been refreshed. True in any case when this
@@ -857,59 +646,6 @@ public class MapEntries implements
 
     // ---------- ResourceChangeListener interface
 
-    /**
-     * Handles the change to any of the node properties relevant for vanity URL
-     * mappings. The {@link #MapEntries(MapConfigurationProvider, BundleContext, EventAdmin, StringInterpolationProvider, Optional)}
-     * constructor makes sure the event listener is registered to only get
-     * appropriate events.
-     */
-    @Override
-    public void onChange(final List<ResourceChange> changes) {
-
-        final boolean inStartup = !vanityPathsProcessed.get();
-
-        final AtomicBoolean resolverRefreshed = new AtomicBoolean(false);
-
-        // send the change event only once
-        boolean sendEvent = false;
-
-        // the config needs to be reloaded only once
-        final AtomicBoolean hasReloadedConfig = new AtomicBoolean(false);
-
-        for (final ResourceChange rc : changes) {
-
-            final ResourceChange.ChangeType type = rc.getType();
-            final String path = rc.getPath();
-
-            log.debug("onChange, type={}, path={}", rc.getType(), path);
-
-            // don't care for system area
-            if (path.startsWith(JCR_SYSTEM_PREFIX)) {
-                continue;
-            }
-
-            // during startup: just enqueue the events
-            if (inStartup) {
-                if (type == ResourceChange.ChangeType.REMOVED || type == ResourceChange.ChangeType.ADDED
-                        || type == ResourceChange.ChangeType.CHANGED) {
-                    Map.Entry<String, ResourceChange.ChangeType> entry = new SimpleEntry<>(path, type);
-                    log.trace("enqueue: {}", entry);
-                    resourceChangeQueue.add(entry);
-                }
-            } else {
-                boolean changed = handleResourceChange(type, path, resolverRefreshed, hasReloadedConfig);
-
-                if (changed) {
-                    sendEvent = true;
-                }
-            }
-        }
-
-        if (sendEvent) {
-            this.sendChangeEvent();
-        }
-    }
-
     private boolean handleResourceChange(ResourceChange.ChangeType type, String path, AtomicBoolean resolverRefreshed,
             AtomicBoolean hasReloadedConfig) {
         boolean changed = false;
@@ -949,96 +685,6 @@ public class MapEntries implements
     }
 
     // ---------- internal
-
-    private byte[] createVanityBloomFilter() throws IOException {
-        return BloomFilterUtils.createFilter(VANITY_BLOOM_FILTER_MAX_ENTRIES, this.factory.getVanityBloomFilterMaxBytes());
-    }
-
-    private boolean isAllVanityPathEntriesCached() {
-        return this.factory.getMaxCachedVanityPathEntries() == -1;
-    }
-
-    /**
-     * get the vanity paths  Search for all nodes having a specific vanityPath
-     */
-    private Map<String, List<MapEntry>> getVanityPaths(String vanityPath) {
-
-        Map<String, List<MapEntry>> entryMap = new HashMap<>();
-
-        final String queryString = String.format(
-                "SELECT [sling:vanityPath], [sling:redirect], [sling:redirectStatus] FROM [nt:base] "
-                        + "WHERE %s AND ([sling:vanityPath]='%s' OR [sling:vanityPath]='%s') "
-                        + "ORDER BY [sling:vanityOrder] DESC",
-                QueryBuildHelper.excludeSystemPath(),
-                QueryBuildHelper.escapeString(vanityPath),
-                QueryBuildHelper.escapeString(vanityPath.substring(1)));
-
-        try (ResourceResolver queryResolver = factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo("mapping"));) {
-            long totalCount = 0;
-            long totalValid = 0;
-            log.debug("start vanityPath query: {}", queryString);
-            final Iterator<Resource> i = queryResolver.findResources(queryString, "JCR-SQL2");
-            log.debug("end vanityPath query");
-            while (i.hasNext()) {
-                totalCount += 1;
-                final Resource resource = i.next();
-                boolean isValid = false;
-                for(final Path sPath : this.factory.getObservationPaths()) {
-                    if ( sPath.matches(resource.getPath())) {
-                        isValid = true;
-                        break;
-                    }
-                }
-                if ( isValid ) {
-                    totalValid += 1;
-                    if (this.vanityPathsProcessed.get() && (this.factory.isMaxCachedVanityPathEntriesStartup() || vanityCounter.longValue() < this.factory.getMaxCachedVanityPathEntries())) {
-                        loadVanityPath(resource, resolveMapsMap, vanityTargets, true, true);
-                        entryMap = resolveMapsMap;
-                    } else {
-                        final Map <String, List<String>> targetPaths = new HashMap<>();
-                        loadVanityPath(resource, entryMap, targetPaths, true, false);
-                    }
-                }
-            }
-            log.debug("read {} ({} valid) vanityPaths", totalCount, totalValid);
-        } catch (LoginException e) {
-            log.error("Exception while obtaining queryResolver", e);
-        }
-        return entryMap;
-    }
-
-    /**
-     * Check if the path is a valid vanity path
-     * @param path The resource path to check
-     * @return {@code true} if this is valid, {@code false} otherwise
-     */
-    private boolean isValidVanityPath(final String path){
-        if (path == null) {
-            throw new IllegalArgumentException("Unexpected null path");
-        }
-
-        // ignore system tree
-        if (path.startsWith(JCR_SYSTEM_PREFIX)) {
-            log.debug("isValidVanityPath: not valid {}", path);
-            return false;
-        }
-
-        // check allow/deny list
-        if ( this.factory.getVanityPathConfig() != null ) {
-            boolean allowed = false;
-            for(final VanityPathConfig config : this.factory.getVanityPathConfig()) {
-                if ( path.startsWith(config.prefix) ) {
-                    allowed = !config.isExclude;
-                    break;
-                }
-            }
-            if ( !allowed ) {
-                log.debug("isValidVanityPath: not valid as not in allow list {}", path);
-                return false;
-            }
-        }
-        return true;
-    }
 
     private String getActualContentPath(final String path){
         final String checkPath;
@@ -1365,150 +1011,6 @@ public class MapEntries implements
         return it;
     }
 
-    /**
-     * Load vanity paths - search for all nodes (except under /jcr:system)
-     * having a sling:vanityPath property
-     */
-    private Map<String, List<String>> loadVanityPaths(ResourceResolver resolver) {
-        final Map<String, List<String>> targetPaths = new ConcurrentHashMap<>();
-        final String baseQueryString = "SELECT [sling:vanityPath], [sling:redirect], [sling:redirectStatus]" + " FROM [nt:base]"
-                + " WHERE " + QueryBuildHelper.excludeSystemPath() + " AND [sling:vanityPath] IS NOT NULL";
-
-        Iterator<Resource> it;
-        try {
-            final String queryStringWithSort = baseQueryString + " AND FIRST([sling:vanityPath]) >= '%s' ORDER BY FIRST([sling:vanityPath])";
-            it = new PagedQueryIterator("vanity path", PROP_VANITY_PATH, resolver, queryStringWithSort, 2000);
-        } catch (QuerySyntaxException ex) {
-            log.debug("sort with first() not supported, falling back to base query", ex);
-            it = queryUnpaged("vanity path", baseQueryString);
-        } catch (UnsupportedOperationException ex) {
-            log.debug("query failed as unsupported, retrying without paging/sorting", ex);
-            it = queryUnpaged("vanity path", baseQueryString);
-        }
-
-        long count = 0;
-        long countInScope = 0;
-        long processStart = System.nanoTime();
-
-        while (it.hasNext()) {
-            count += 1;
-            final Resource resource = it.next();
-            final String resourcePath = resource.getPath();
-            if (Stream.of(this.factory.getObservationPaths()).anyMatch(path -> path.matches(resourcePath))) {
-                countInScope += 1;
-                final boolean addToCache = isAllVanityPathEntriesCached()
-                        || vanityCounter.longValue() < this.factory.getMaxCachedVanityPathEntries();
-                loadVanityPath(resource, resolveMapsMap, targetPaths, addToCache, true);
-            }
-        }
-        long processElapsed = System.nanoTime() - processStart;
-        log.debug("processed {} resources with sling:vanityPath properties (of which {} in scope) in {}ms", count, countInScope, TimeUnit.NANOSECONDS.toMillis(processElapsed));
-        if (!isAllVanityPathEntriesCached()) {
-            if (countInScope > this.factory.getMaxCachedVanityPathEntries()) {
-                log.warn("Number of resources with sling:vanityPath property ({}) exceeds configured cache size ({}); handling of uncached vanity paths will be much slower. Consider increasing the cache size or decreasing the number of vanity paths.", countInScope, this.factory.getMaxCachedVanityPathEntries());
-            } else if (countInScope > (this.factory.getMaxCachedVanityPathEntries() / 10) * 9) {
-                log.info("Number of resources with sling:vanityPath property in scope ({}) within 10% of configured cache size ({})", countInScope, this.factory.getMaxCachedVanityPathEntries());
-            }
-        }
-
-        this.vanityResourcesOnStartup.set(count);
-
-        return targetPaths;
-    }
-
-    /**
-     * Load vanity path given a resource
-     * 
-     * @return first vanity path or {@code null}
-     */
-    private String loadVanityPath(final Resource resource, final Map<String, List<MapEntry>> entryMap, final Map <String, List<String>> targetPaths, boolean addToCache, boolean updateCounter) {
-
-        if (!isValidVanityPath(resource.getPath())) {
-            return null;
-        }
-
-        final ValueMap props = resource.getValueMap();
-        long vanityOrder = props.get(PROP_VANITY_ORDER, 0L);
-
-        // url is ignoring scheme and host.port and the path is
-        // what is stored in the sling:vanityPath property
-        boolean hasVanityPath = false;
-        final String[] pVanityPaths = props.get(PROP_VANITY_PATH, new String[0]);
-        if (log.isTraceEnabled()) {
-            log.trace("vanity paths on {}: {}", resource.getPath(), Arrays.asList(pVanityPaths));
-        }
-
-        for (final String pVanityPath : pVanityPaths) {
-            final String[] result = this.getVanityPathDefinition(resource.getPath(), pVanityPath);
-            if (result != null) {
-                // redirect target is the node providing the sling:vanityPath
-                // property (or its parent if the node is called jcr:content)
-                final Resource redirectTarget;
-                if (JCR_CONTENT.equals(resource.getName())) {
-                    redirectTarget = resource.getParent();
-                    if (redirectTarget == null) {
-                        // we encountered a broken resource jcr:content resource
-                        // that apparently has no parent; skip this one and
-                        // continue with next
-                        log.warn("containingResource is null for vanity path on {}, skipping.", resource.getPath());
-                        continue;
-                    }
-                } else {
-                    redirectTarget = resource;
-                }
-
-                hasVanityPath = true;
-                final String url = result[0] + result[1];
-                final String redirect = redirectTarget.getPath();
-                final String redirectName = redirectTarget.getName();
-
-                // whether the target is attained by a external redirect or
-                // by an internal redirect is defined by the sling:redirect
-                // property
-                final int status = props.get(PROP_REDIRECT_EXTERNAL, false) ? props.get(
-                        PROP_REDIRECT_EXTERNAL_REDIRECT_STATUS, factory.getDefaultVanityPathRedirectStatus())
-                        : -1;
-
-                final String checkPath = result[1];
-
-                boolean addedEntry;
-                if (addToCache) {
-                    if (redirectName.indexOf('.') > -1) {
-                        // 1. entry with exact match
-                        this.addEntry(entryMap, checkPath, getMapEntry(url + "$", status, vanityOrder, redirect));
-
-                        final int idx = redirectName.lastIndexOf('.');
-                        final String extension = redirectName.substring(idx + 1);
-
-                        // 2. entry with extension
-                        addedEntry = this.addEntry(entryMap, checkPath, getMapEntry(url + "\\." + extension, status, vanityOrder, redirect));
-                    } else {
-                        // 1. entry with exact match
-                        this.addEntry(entryMap, checkPath, getMapEntry(url + "$", status, vanityOrder, redirect + ".html"));
-
-                        // 2. entry with match supporting selectors and extension
-                        addedEntry = this.addEntry(entryMap, checkPath, getMapEntry(url + "(\\..*)", status, vanityOrder, redirect + "$1"));
-                    }
-                    if (addedEntry) {
-                        // 3. keep the path to return
-                        this.updateTargetPaths(targetPaths, redirect, checkPath);
-
-                        if (updateCounter) {
-                            vanityCounter.addAndGet(2);
-                        }
-
-                        // update bloom filter
-                        BloomFilterUtils.add(vanityBloomFilter, checkPath);
-                    }
-                } else {
-                    // update bloom filter
-                    BloomFilterUtils.add(vanityBloomFilter, checkPath);
-                }
-            }
-        }
-        return hasVanityPath ? pVanityPaths[0] : null;
-    }
-
     private void updateTargetPaths(final Map<String, List<String>> targetPaths, final String key, final String entry) {
         if (entry == null) {
            return;
@@ -1519,58 +1021,6 @@ public class MapEntries implements
             targetPaths.put(key, entries);
         }
         entries.add(entry);
-    }
-
-    /**
-     * Create the vanity path definition. String array containing:
-     * {protocol}/{host}[.port] {absolute path}
-     */
-    private String[] getVanityPathDefinition(final String sourcePath, final String vanityPath) {
-
-        if (vanityPath == null) {
-            log.trace("getVanityPathDefinition: null vanity path on {}", sourcePath);
-            return null;
-        }
-
-        String info = vanityPath.trim();
-
-        if (info.isEmpty()) {
-            log.trace("getVanityPathDefinition: empty vanity path on {}", sourcePath);
-            return null;
-        }
-
-        String prefix = null;
-        String path = null;
-
-        // check for URL-shaped path
-        if (info.indexOf(":/") > -1) {
-            try {
-                final URL u = new URL(info);
-                prefix = u.getProtocol() + '/' + u.getHost() + '.' + u.getPort();
-                path = u.getPath();
-            } catch (final MalformedURLException e) {
-                log.warn("Ignoring malformed vanity path '{}' on {}", info, sourcePath);
-                return null;
-            }
-        } else {
-            prefix = "^" + ANY_SCHEME_HOST;
-
-            if (!info.startsWith("/")) {
-                path = "/" + info;
-            } else {
-                path = info;
-            }
-        }
-
-        // remove extension
-        int lastSlash = path.lastIndexOf('/');
-        int firstDot = path.indexOf('.', lastSlash + 1);
-        if (firstDot != -1) {
-            path = path.substring(0, firstDot);
-            log.warn("Removing extension from vanity path '{}' on {}", info, sourcePath);
-        }
-
-        return new String[] { prefix, path };
     }
 
     private void loadConfiguration(final MapConfigurationProvider factory, final List<MapEntry> entries) {
@@ -1688,18 +1138,6 @@ public class MapEntries implements
         }
     }
 
-    // return vanity path entry iterator from cache when complete and ready, otherwise from
-    // regular lockup
-    public @Nullable Iterator<MapEntry> getCurrentMapEntryForVanityPath(final String key) {
-        List<MapEntry> l;
-        if (this.isAllVanityPathEntriesCached() && this.vanityPathsProcessed.get()) {
-            l = this.resolveMapsMap.get(key);
-        } else {
-            l = this.getMapEntryList(key);
-        }
-        return l == null ? null : l.iterator();
-    }
-
     private MapEntry getMapEntry(final String url, final int status, final String... redirect) {
         return getMapEntry(url, status, 0, redirect);
     }
@@ -1713,5 +1151,569 @@ public class MapEntries implements
             log.debug("ignored entry for {} due to exception", url, iae);
             return null;
         }
+    }
+
+    // ---- vanity path handling ----
+
+    /**
+     * Actual vanity paths initializer. Guards itself against concurrent use by
+     * using a ReentrantLock. Does nothing if the resource resolver has already
+     * been null-ed.
+     *
+     * @throws IOException in case of problems
+     */
+    protected void initializeVanityPaths() throws IOException {
+        this.initializing.lock();
+        try {
+            if (this.factory.isVanityPathEnabled()) {
+                this.vanityBloomFilter = createVanityBloomFilter();
+                VanityPathInitializer vpi = new VanityPathInitializer(this.factory);
+                if (this.factory.isVanityPathCacheInitInBackground()) {
+                    this.log.debug("bg init starting");
+                    Thread vpinit = new Thread(vpi, "VanityPathInitializer");
+                    vpinit.start();
+                } else {
+                    vpi.run();
+                }
+            }
+        } finally {
+            this.initializing.unlock();
+        }
+    }
+
+    private boolean removeVanityPath(final String path) {
+        this.initializing.lock();
+        try {
+            return doRemoveVanity(path);
+        } finally {
+            this.initializing.unlock();
+        }
+    }
+
+    private class VanityPathInitializer implements Runnable {
+
+        private int SIZELIMIT = 10000;
+
+        private MapConfigurationProvider factory;
+
+        public VanityPathInitializer(MapConfigurationProvider factory) {
+            this.factory = factory;
+        }
+
+        @Override
+        public void run() {
+            try {
+                temporaryResolveMapsMap = Collections.synchronizedMap(new LRUMap<>(SIZELIMIT));
+                execute();
+            } catch (Throwable t) {
+                log.error("vanity path initializer thread terminated with a throwable", t);
+            }
+        }
+
+        private void drainQueue(List<Map.Entry<String, ResourceChange.ChangeType>> queue) {
+            final AtomicBoolean resolverRefreshed = new AtomicBoolean(false);
+
+            // send the change event only once
+            boolean sendEvent = false;
+
+            // the config needs to be reloaded only once
+            final AtomicBoolean hasReloadedConfig = new AtomicBoolean(false);
+
+            while (!queue.isEmpty()) {
+                Map.Entry<String, ResourceChange.ChangeType> entry = queue.remove(0);
+                final ResourceChange.ChangeType type = entry.getValue();
+                final String path = entry.getKey();
+
+                log.trace("drain type={}, path={}", type, path);
+                boolean changed = handleResourceChange(type, path, resolverRefreshed, hasReloadedConfig);
+
+                if (changed) {
+                    sendEvent = true;
+                }
+            }
+
+            if (sendEvent) {
+                sendChangeEvent();
+            }
+        }
+
+        private void execute() {
+            try (ResourceResolver resolver = factory
+                    .getServiceResourceResolver(factory.getServiceUserAuthenticationInfo("mapping"))) {
+
+                long initStart = System.nanoTime();
+                log.debug("vanity path initialization - start");
+
+                vanityTargets = loadVanityPaths(resolver);
+
+                // process pending event
+                drainQueue(resourceChangeQueue);
+
+                vanityPathsProcessed.set(true);
+
+                // drain once more in case more events have arrived
+                drainQueue(resourceChangeQueue);
+
+                long initElapsed = System.nanoTime() - initStart;
+                long resourcesPerSecond = (vanityResourcesOnStartup.get() * TimeUnit.SECONDS.toNanos(1) / (initElapsed == 0 ? 1 : initElapsed));
+
+                log.info(
+                        "vanity path initialization - completed, processed {} resources with sling:vanityPath properties in {}ms (~{} resource/s)",
+                        vanityResourcesOnStartup.get(), TimeUnit.NANOSECONDS.toMillis(initElapsed), resourcesPerSecond);
+            } catch (LoginException ex) {
+                log.error("Vanity path init failed", ex);
+            } finally {
+                log.debug("dropping temporary resolver map - {}/{} entries, {} hits, {} misses", temporaryResolveMapsMap.size(),
+                        SIZELIMIT, temporaryResolveMapsMapHits.get(), temporaryResolveMapsMapMisses.get());
+                temporaryResolveMapsMap = null;
+            }
+        }
+    }
+
+    private boolean doAddVanity(final Resource resource) {
+        log.debug("doAddVanity getting {}", resource.getPath());
+
+        boolean updateTheCache = isAllVanityPathEntriesCached() || vanityCounter.longValue() < this.factory.getMaxCachedVanityPathEntries();
+        return null != loadVanityPath(resource, resolveMapsMap, vanityTargets, updateTheCache, true);
+    }
+
+    private boolean doRemoveVanity(final String path) {
+        final String actualContentPath = getActualContentPath(path);
+        final List <String> l = vanityTargets.remove(actualContentPath);
+        if (l != null){
+            for (final String s : l){
+                final List<MapEntry> entries = this.resolveMapsMap.get(s);
+                if (entries!= null) {
+                    for (final Iterator<MapEntry> iterator =entries.iterator(); iterator.hasNext(); ) {
+                        final MapEntry entry = iterator.next();
+                        final String redirect = getMapEntryRedirect(entry);
+                        if (redirect != null && redirect.equals(actualContentPath)) {
+                            iterator.remove();
+                        }
+                    }
+                }
+                if (entries!= null && entries.isEmpty()) {
+                    this.resolveMapsMap.remove(s);
+                }
+            }
+            if (vanityCounter.longValue() > 0) {
+                vanityCounter.addAndGet(-2);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * get the MapEntry list containing all the nodes having a specific vanityPath
+     */
+    private List<MapEntry> getMapEntryList(String vanityPath) {
+        List<MapEntry> mapEntries = null;
+
+        boolean initFinished = vanityPathsProcessed.get();
+        boolean probablyPresent = false;
+
+        if (initFinished) {
+            // total number of lookups after init (and when cache not complete)
+            long current = this.vanityPathLookups.incrementAndGet();
+            if (current >= Long.MAX_VALUE - 100000) {
+                // reset counters when we get close the limit
+                this.vanityPathLookups.set(1);
+                this.vanityPathBloomNegatives.set(0);
+                this.vanityPathBloomFalsePositives.set(0);
+                log.info("Vanity Path metrics reset to 0");
+            }
+
+            // init is done - check the bloom filter
+            probablyPresent = BloomFilterUtils.probablyContains(vanityBloomFilter, vanityPath);
+            log.trace("bloom filter lookup for {} -> {}", vanityPath, probablyPresent);
+
+            if (!probablyPresent) {
+                // filtered by Bloom filter
+                this.vanityPathBloomNegatives.incrementAndGet();
+            }
+        }
+
+        if (!initFinished || probablyPresent) {
+
+            mapEntries = this.resolveMapsMap.get(vanityPath);
+
+            if (mapEntries == null) {
+                if (!initFinished && temporaryResolveMapsMap != null) {
+                    mapEntries = temporaryResolveMapsMap.get(vanityPath);
+                    if (mapEntries != null) {
+                        temporaryResolveMapsMapHits.incrementAndGet();
+                        log.trace("getMapEntryList: using temp map entries for {} -> {}", vanityPath, mapEntries);
+                    } else {
+                        temporaryResolveMapsMapMisses.incrementAndGet();
+                    }
+                }
+                if (mapEntries == null) {
+                    Map<String, List<MapEntry>> mapEntry = getVanityPaths(vanityPath);
+                    mapEntries = mapEntry.get(vanityPath);
+                    if (!initFinished && temporaryResolveMapsMap != null) {
+                        log.trace("getMapEntryList: caching map entries for {} -> {}", vanityPath, mapEntries);
+                        temporaryResolveMapsMap.put(vanityPath, mapEntries == null ? NO_MAP_ENTRIES : mapEntries);
+                    }
+                }
+            }
+            if (mapEntries == null && probablyPresent) {
+                // Bloom filter had a false positive
+                this.vanityPathBloomFalsePositives.incrementAndGet();
+            }
+        }
+
+        return mapEntries == NO_MAP_ENTRIES ? null : mapEntries;
+    }
+
+    /**
+     * Handles the change to any of the node properties relevant for vanity URL
+     * mappings. The {@link #MapEntries(MapConfigurationProvider, BundleContext, EventAdmin, StringInterpolationProvider, Optional)}
+     * constructor makes sure the event listener is registered to only get
+     * appropriate events.
+     */
+    @Override
+    public void onChange(final List<ResourceChange> changes) {
+
+        final boolean inStartup = !vanityPathsProcessed.get();
+
+        final AtomicBoolean resolverRefreshed = new AtomicBoolean(false);
+
+        // send the change event only once
+        boolean sendEvent = false;
+
+        // the config needs to be reloaded only once
+        final AtomicBoolean hasReloadedConfig = new AtomicBoolean(false);
+
+        for (final ResourceChange rc : changes) {
+
+            final ResourceChange.ChangeType type = rc.getType();
+            final String path = rc.getPath();
+
+            log.debug("onChange, type={}, path={}", rc.getType(), path);
+
+            // don't care for system area
+            if (path.startsWith(JCR_SYSTEM_PREFIX)) {
+                continue;
+            }
+
+            // during startup: just enqueue the events
+            if (inStartup) {
+                if (type == ResourceChange.ChangeType.REMOVED || type == ResourceChange.ChangeType.ADDED
+                        || type == ResourceChange.ChangeType.CHANGED) {
+                    Map.Entry<String, ResourceChange.ChangeType> entry = new SimpleEntry<>(path, type);
+                    log.trace("enqueue: {}", entry);
+                    resourceChangeQueue.add(entry);
+                }
+            } else {
+                boolean changed = handleResourceChange(type, path, resolverRefreshed, hasReloadedConfig);
+
+                if (changed) {
+                    sendEvent = true;
+                }
+            }
+        }
+
+        if (sendEvent) {
+            this.sendChangeEvent();
+        }
+    }
+
+    private byte[] createVanityBloomFilter() throws IOException {
+        return BloomFilterUtils.createFilter(VANITY_BLOOM_FILTER_MAX_ENTRIES, this.factory.getVanityBloomFilterMaxBytes());
+    }
+
+    private boolean isAllVanityPathEntriesCached() {
+        return this.factory.getMaxCachedVanityPathEntries() == -1;
+    }
+
+    /**
+     * get the vanity paths  Search for all nodes having a specific vanityPath
+     */
+    private Map<String, List<MapEntry>> getVanityPaths(String vanityPath) {
+
+        Map<String, List<MapEntry>> entryMap = new HashMap<>();
+
+        final String queryString = String.format(
+                "SELECT [sling:vanityPath], [sling:redirect], [sling:redirectStatus] FROM [nt:base] "
+                        + "WHERE %s AND ([sling:vanityPath]='%s' OR [sling:vanityPath]='%s') "
+                        + "ORDER BY [sling:vanityOrder] DESC",
+                QueryBuildHelper.excludeSystemPath(),
+                QueryBuildHelper.escapeString(vanityPath),
+                QueryBuildHelper.escapeString(vanityPath.substring(1)));
+
+        try (ResourceResolver queryResolver = factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo("mapping"));) {
+            long totalCount = 0;
+            long totalValid = 0;
+            log.debug("start vanityPath query: {}", queryString);
+            final Iterator<Resource> i = queryResolver.findResources(queryString, "JCR-SQL2");
+            log.debug("end vanityPath query");
+            while (i.hasNext()) {
+                totalCount += 1;
+                final Resource resource = i.next();
+                boolean isValid = false;
+                for(final Path sPath : this.factory.getObservationPaths()) {
+                    if ( sPath.matches(resource.getPath())) {
+                        isValid = true;
+                        break;
+                    }
+                }
+                if ( isValid ) {
+                    totalValid += 1;
+                    if (this.vanityPathsProcessed.get() && (this.factory.isMaxCachedVanityPathEntriesStartup() || vanityCounter.longValue() < this.factory.getMaxCachedVanityPathEntries())) {
+                        loadVanityPath(resource, resolveMapsMap, vanityTargets, true, true);
+                        entryMap = resolveMapsMap;
+                    } else {
+                        final Map <String, List<String>> targetPaths = new HashMap<>();
+                        loadVanityPath(resource, entryMap, targetPaths, true, false);
+                    }
+                }
+            }
+            log.debug("read {} ({} valid) vanityPaths", totalCount, totalValid);
+        } catch (LoginException e) {
+            log.error("Exception while obtaining queryResolver", e);
+        }
+        return entryMap;
+    }
+
+    /**
+     * Check if the path is a valid vanity path
+     * @param path The resource path to check
+     * @return {@code true} if this is valid, {@code false} otherwise
+     */
+    private boolean isValidVanityPath(final String path){
+        if (path == null) {
+            throw new IllegalArgumentException("Unexpected null path");
+        }
+
+        // ignore system tree
+        if (path.startsWith(JCR_SYSTEM_PREFIX)) {
+            log.debug("isValidVanityPath: not valid {}", path);
+            return false;
+        }
+
+        // check allow/deny list
+        if ( this.factory.getVanityPathConfig() != null ) {
+            boolean allowed = false;
+            for(final VanityPathConfig config : this.factory.getVanityPathConfig()) {
+                if ( path.startsWith(config.prefix) ) {
+                    allowed = !config.isExclude;
+                    break;
+                }
+            }
+            if ( !allowed ) {
+                log.debug("isValidVanityPath: not valid as not in allow list {}", path);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Load vanity paths - search for all nodes (except under /jcr:system)
+     * having a sling:vanityPath property
+     */
+    private Map<String, List<String>> loadVanityPaths(ResourceResolver resolver) {
+        final Map<String, List<String>> targetPaths = new ConcurrentHashMap<>();
+        final String baseQueryString = "SELECT [sling:vanityPath], [sling:redirect], [sling:redirectStatus]" + " FROM [nt:base]"
+                + " WHERE " + QueryBuildHelper.excludeSystemPath() + " AND [sling:vanityPath] IS NOT NULL";
+
+        Iterator<Resource> it;
+        try {
+            final String queryStringWithSort = baseQueryString + " AND FIRST([sling:vanityPath]) >= '%s' ORDER BY FIRST([sling:vanityPath])";
+            it = new PagedQueryIterator("vanity path", PROP_VANITY_PATH, resolver, queryStringWithSort, 2000);
+        } catch (QuerySyntaxException ex) {
+            log.debug("sort with first() not supported, falling back to base query", ex);
+            it = queryUnpaged("vanity path", baseQueryString);
+        } catch (UnsupportedOperationException ex) {
+            log.debug("query failed as unsupported, retrying without paging/sorting", ex);
+            it = queryUnpaged("vanity path", baseQueryString);
+        }
+
+        long count = 0;
+        long countInScope = 0;
+        long processStart = System.nanoTime();
+
+        while (it.hasNext()) {
+            count += 1;
+            final Resource resource = it.next();
+            final String resourcePath = resource.getPath();
+            if (Stream.of(this.factory.getObservationPaths()).anyMatch(path -> path.matches(resourcePath))) {
+                countInScope += 1;
+                final boolean addToCache = isAllVanityPathEntriesCached()
+                        || vanityCounter.longValue() < this.factory.getMaxCachedVanityPathEntries();
+                loadVanityPath(resource, resolveMapsMap, targetPaths, addToCache, true);
+            }
+        }
+        long processElapsed = System.nanoTime() - processStart;
+        log.debug("processed {} resources with sling:vanityPath properties (of which {} in scope) in {}ms", count, countInScope, TimeUnit.NANOSECONDS.toMillis(processElapsed));
+        if (!isAllVanityPathEntriesCached()) {
+            if (countInScope > this.factory.getMaxCachedVanityPathEntries()) {
+                log.warn("Number of resources with sling:vanityPath property ({}) exceeds configured cache size ({}); handling of uncached vanity paths will be much slower. Consider increasing the cache size or decreasing the number of vanity paths.", countInScope, this.factory.getMaxCachedVanityPathEntries());
+            } else if (countInScope > (this.factory.getMaxCachedVanityPathEntries() / 10) * 9) {
+                log.info("Number of resources with sling:vanityPath property in scope ({}) within 10% of configured cache size ({})", countInScope, this.factory.getMaxCachedVanityPathEntries());
+            }
+        }
+
+        this.vanityResourcesOnStartup.set(count);
+
+        return targetPaths;
+    }
+
+    /**
+     * Load vanity path given a resource
+     *
+     * @return first vanity path or {@code null}
+     */
+    private String loadVanityPath(final Resource resource, final Map<String, List<MapEntry>> entryMap, final Map <String, List<String>> targetPaths, boolean addToCache, boolean updateCounter) {
+
+        if (!isValidVanityPath(resource.getPath())) {
+            return null;
+        }
+
+        final ValueMap props = resource.getValueMap();
+        long vanityOrder = props.get(PROP_VANITY_ORDER, 0L);
+
+        // url is ignoring scheme and host.port and the path is
+        // what is stored in the sling:vanityPath property
+        boolean hasVanityPath = false;
+        final String[] pVanityPaths = props.get(PROP_VANITY_PATH, new String[0]);
+        if (log.isTraceEnabled()) {
+            log.trace("vanity paths on {}: {}", resource.getPath(), Arrays.asList(pVanityPaths));
+        }
+
+        for (final String pVanityPath : pVanityPaths) {
+            final String[] result = this.getVanityPathDefinition(resource.getPath(), pVanityPath);
+            if (result != null) {
+                // redirect target is the node providing the sling:vanityPath
+                // property (or its parent if the node is called jcr:content)
+                final Resource redirectTarget;
+                if (JCR_CONTENT.equals(resource.getName())) {
+                    redirectTarget = resource.getParent();
+                    if (redirectTarget == null) {
+                        // we encountered a broken resource jcr:content resource
+                        // that apparently has no parent; skip this one and
+                        // continue with next
+                        log.warn("containingResource is null for vanity path on {}, skipping.", resource.getPath());
+                        continue;
+                    }
+                } else {
+                    redirectTarget = resource;
+                }
+
+                hasVanityPath = true;
+                final String url = result[0] + result[1];
+                final String redirect = redirectTarget.getPath();
+                final String redirectName = redirectTarget.getName();
+
+                // whether the target is attained by a external redirect or
+                // by an internal redirect is defined by the sling:redirect
+                // property
+                final int status = props.get(PROP_REDIRECT_EXTERNAL, false) ? props.get(
+                        PROP_REDIRECT_EXTERNAL_REDIRECT_STATUS, factory.getDefaultVanityPathRedirectStatus())
+                        : -1;
+
+                final String checkPath = result[1];
+
+                boolean addedEntry;
+                if (addToCache) {
+                    if (redirectName.indexOf('.') > -1) {
+                        // 1. entry with exact match
+                        this.addEntry(entryMap, checkPath, getMapEntry(url + "$", status, vanityOrder, redirect));
+
+                        final int idx = redirectName.lastIndexOf('.');
+                        final String extension = redirectName.substring(idx + 1);
+
+                        // 2. entry with extension
+                        addedEntry = this.addEntry(entryMap, checkPath, getMapEntry(url + "\\." + extension, status, vanityOrder, redirect));
+                    } else {
+                        // 1. entry with exact match
+                        this.addEntry(entryMap, checkPath, getMapEntry(url + "$", status, vanityOrder, redirect + ".html"));
+
+                        // 2. entry with match supporting selectors and extension
+                        addedEntry = this.addEntry(entryMap, checkPath, getMapEntry(url + "(\\..*)", status, vanityOrder, redirect + "$1"));
+                    }
+                    if (addedEntry) {
+                        // 3. keep the path to return
+                        this.updateTargetPaths(targetPaths, redirect, checkPath);
+
+                        if (updateCounter) {
+                            vanityCounter.addAndGet(2);
+                        }
+
+                        // update bloom filter
+                        BloomFilterUtils.add(vanityBloomFilter, checkPath);
+                    }
+                } else {
+                    // update bloom filter
+                    BloomFilterUtils.add(vanityBloomFilter, checkPath);
+                }
+            }
+        }
+        return hasVanityPath ? pVanityPaths[0] : null;
+    }
+
+    /**
+     * Create the vanity path definition. String array containing:
+     * {protocol}/{host}[.port] {absolute path}
+     */
+    private String[] getVanityPathDefinition(final String sourcePath, final String vanityPath) {
+
+        if (vanityPath == null) {
+            log.trace("getVanityPathDefinition: null vanity path on {}", sourcePath);
+            return null;
+        }
+
+        String info = vanityPath.trim();
+
+        if (info.isEmpty()) {
+            log.trace("getVanityPathDefinition: empty vanity path on {}", sourcePath);
+            return null;
+        }
+
+        String prefix = null;
+        String path = null;
+
+        // check for URL-shaped path
+        if (info.indexOf(":/") > -1) {
+            try {
+                final URL u = new URL(info);
+                prefix = u.getProtocol() + '/' + u.getHost() + '.' + u.getPort();
+                path = u.getPath();
+            } catch (final MalformedURLException e) {
+                log.warn("Ignoring malformed vanity path '{}' on {}", info, sourcePath);
+                return null;
+            }
+        } else {
+            prefix = "^" + ANY_SCHEME_HOST;
+
+            if (!info.startsWith("/")) {
+                path = "/" + info;
+            } else {
+                path = info;
+            }
+        }
+
+        // remove extension
+        int lastSlash = path.lastIndexOf('/');
+        int firstDot = path.indexOf('.', lastSlash + 1);
+        if (firstDot != -1) {
+            path = path.substring(0, firstDot);
+            log.warn("Removing extension from vanity path '{}' on {}", info, sourcePath);
+        }
+
+        return new String[] { prefix, path };
+    }
+
+    // return vanity path entry iterator from cache when complete and ready, otherwise from
+    // regular lockup
+    public @Nullable Iterator<MapEntry> getCurrentMapEntryForVanityPath(final String key) {
+        List<MapEntry> l;
+        if (this.isAllVanityPathEntriesCached() && this.vanityPathsProcessed.get()) {
+            l = this.resolveMapsMap.get(key);
+        } else {
+            l = this.getMapEntryList(key);
+        }
+        return l == null ? null : l.iterator();
     }
 }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
@@ -19,7 +19,6 @@ package org.apache.sling.resourceresolver.impl.mapping;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,15 +26,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,9 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,31 +47,20 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.observation.ResourceChange;
-import org.apache.sling.api.resource.observation.ResourceChange.ChangeType;
 import org.apache.sling.api.resource.path.Path;
-import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.resourceresolver.impl.ResourceResolverImpl;
 import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
-import org.apache.sling.resourceresolver.impl.mapping.MapConfigurationProvider.VanityPathConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.event.EventAdmin;
-import org.osgi.service.event.Event;
 
-@RunWith(Parameterized.class)
 public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
     private MapEntries mapEntries;
@@ -103,64 +84,32 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
     private AtomicLong detectedInvalidAliases;
     private AtomicLong detectedConflictingAliases;
 
-    private int testSize = 5;
-
-    private int pageSize;
-    private int prevPageSize = 1000;
-
-    @Parameters(name = "page size -> {0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { 1 }, { 1000 } });
-    }
-
-    public MapEntriesTest(int pageSize) {
-        this.pageSize = pageSize;
+    public MapEntriesTest() {
     }
 
     @Override
     @SuppressWarnings({ "unchecked" })
     @Before
     public void setup() throws Exception {
-        prevPageSize = Integer.getInteger("sling.vanityPath.pageSize", 2000);
-        System.setProperty("sling.vanityPath.pageSize", Integer.toString(pageSize));
-
         MockitoAnnotations.openMocks(this);
 
-        final List<VanityPathConfig> configs = new ArrayList<>();
-        configs.add(new VanityPathConfig("/libs/", false));
-        configs.add(new VanityPathConfig("/libs/denied", true));
-        configs.add(new VanityPathConfig("/foo/", false));
-        configs.add(new VanityPathConfig("/baa/", false));
-        configs.add(new VanityPathConfig("/justVanityPath", false));
-        configs.add(new VanityPathConfig("/justVanityPath2", false));
-        configs.add(new VanityPathConfig("/badVanityPath", false));
-        configs.add(new VanityPathConfig("/redirectingVanityPath", false));
-        configs.add(new VanityPathConfig("/redirectingVanityPath301", false));
-        configs.add(new VanityPathConfig("/vanityPathOnJcrContent", false));
-
-        Collections.sort(configs);
         when(bundle.getSymbolicName()).thenReturn("TESTBUNDLE");
         when(bundleContext.getBundle()).thenReturn(bundle);
         when(resourceResolverFactory.getServiceResourceResolver(any(Map.class))).thenReturn(resourceResolver);
         when(resourceResolverFactory.isVanityPathEnabled()).thenReturn(true);
-        when(resourceResolverFactory.getVanityPathConfig()).thenReturn(configs);
+        when(resourceResolverFactory.getVanityPathConfig()).thenReturn(List.of());
         when(resourceResolverFactory.isOptimizeAliasResolutionEnabled()).thenReturn(true);
         when(resourceResolverFactory.getObservationPaths()).thenReturn(new Path[] {new Path("/")});
         when(resourceResolverFactory.getMapRoot()).thenReturn(MapEntries.DEFAULT_MAP_ROOT);
         when(resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(-1L);
         when(resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(true);
         when(resourceResolver.findResources(anyString(), eq("sql"))).thenReturn(
-                Collections.<Resource> emptySet().iterator());
+                Collections.emptyIterator());
         when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenReturn(
-                Collections.<Resource> emptySet().iterator());
+                Collections.emptyIterator());
         //when(resourceResolverFactory.getAliasPath()).thenReturn(Arrays.asList("/child"));
 
-        Set<String> aliasPath = new TreeSet<>();
-        aliasPath.add("/parent");
-        for(int i = 1; i < testSize; i++){
-          aliasPath.add("/parent"+i);
-        }
-        when(resourceResolverFactory.getAllowedAliasLocations()).thenReturn(aliasPath);
+        when(resourceResolverFactory.getAllowedAliasLocations()).thenReturn(Set.of());
 
         Optional<ResourceResolverMetrics> metrics = Optional.empty();
 
@@ -181,8 +130,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
     @Override
     @After
-    public void tearDown() throws Exception {
-        System.setProperty("sling.vanityPath.pageSize", Integer.toString(prevPageSize));
+    public void tearDown() {
         mapEntries.dispose();
     }
 
@@ -286,90 +234,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
     }
 
     @Test
-    public void test_simple_vanity_path() throws IOException {
-        String vanityPath = "/xyz";
-        String containerName = "foo";
-        String childName = "child";
-        String oneMore = "one-more";
-        prepareMapEntriesForVanityPath(false, false, containerName,
-                childName, oneMore, vanityPath);
-        mapEntries.doInit();
-        mapEntries.initializeVanityPaths();
-        Map<String, List<String>> vanityMap = mapEntries.getVanityPathMappings();
-        assertNotNull(vanityMap);
-        assertEquals(vanityPath, vanityMap.get("/" + containerName + "/" + childName).get(0));
-        assertEquals(2, vanityMap.size());
-        assertNotNull(vanityMap.get("/" + containerName + "/" + oneMore));
-    }
-
-    // see SLING-12620
-    @Test
-    public void test_simple_vanity_path_support_with_null_parent() throws IOException {
-        String vanityPath = "/xyz";
-        String containerName = "foo";
-        String childName = "child";
-        String oneMore = "one-more";
-        prepareMapEntriesForVanityPath(true, true, containerName,
-                childName, oneMore, vanityPath);
-        mapEntries.doInit();
-        mapEntries.initializeVanityPaths();
-        Map<String, List<String>> vanityMap = mapEntries.getVanityPathMappings();
-        assertNotNull(vanityMap);
-        // not present
-        assertNull(vanityMap.get("/" + containerName + "/" + childName));
-        assertNull(vanityMap.get("/" + containerName + "/" + childName + "/jcr:content"));
-        // but the other one is present
-        assertEquals(1, vanityMap.size());
-        assertNotNull(vanityMap.get("/" + containerName + "/" + oneMore));
-    }
-
-    // create a 'custom' node (two flags), followed by a hardwired one (this is used to check that vanity path
-    // processing does not abort after the first error
-    private void prepareMapEntriesForVanityPath(boolean onJcrContent, boolean withNullParent,
-                                                String containerName, String childName,
-                                                String additionalChildName, String vanityPath) {
-
-        final Resource parent = mock(Resource.class);
-
-        when(parent.getParent()).thenReturn(null);
-        when(parent.getPath()).thenReturn("/" + containerName);
-        when(parent.getName()).thenReturn(containerName);
-
-        final Resource vanity = mock(Resource.class);
-
-        when(vanity.getParent()).thenReturn(withNullParent && !onJcrContent ? null : parent);
-        when(vanity.getPath()).thenReturn("/" + containerName + "/" + childName);
-        when(vanity.getName()).thenReturn(childName);
-
-        final Resource content = mock(Resource.class);
-
-        when(content.getParent()).thenReturn(withNullParent && onJcrContent ? null : vanity);
-        when(content.getPath()).thenReturn("/" + containerName + "/" + childName + "/jcr:content");
-        when(content.getName()).thenReturn("jcr:content");
-
-        final Resource oneMore = mock(Resource.class);
-
-        when(oneMore.getParent()).thenReturn(parent);
-        when(oneMore.getPath()).thenReturn("/" + containerName + "/" + additionalChildName);
-        when(oneMore.getName()).thenReturn(additionalChildName);
-
-        when(oneMore.getValueMap()).thenReturn(buildValueMap(MapEntries.PROP_VANITY_PATH, vanityPath + "/onemore"));
-
-        final Resource vanityPropHolder = onJcrContent ? content : vanity;
-
-        when(vanityPropHolder.getValueMap()).thenReturn(buildValueMap(MapEntries.PROP_VANITY_PATH, vanityPath));
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
-            if (invocation.getArguments()[0].toString().contains(MapEntries.PROP_VANITY_PATH)) {
-                return List.of(vanityPropHolder, oneMore).iterator();
-            } else {
-                return Collections.emptyIterator();
-            }
-        });
-    }
-
-    @Test
-    public void test_that_duplicate_alias_doesnt_replace_first_alias() {
+    public void test_that_duplicate_alias_does_not_replace_first_alias() {
         Resource parent = mock(Resource.class);
         when(parent.getPath()).thenReturn("/parent");
 
@@ -385,15 +250,11 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         when(secondResult.getName()).thenReturn("child2");
         when(secondResult.getValueMap()).thenReturn(buildValueMap(ResourceResolverImpl.PROP_ALIAS, "alias"));
 
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains(ResourceResolverImpl.PROP_ALIAS)) {
-                    return Arrays.asList(result, secondResult).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains(ResourceResolverImpl.PROP_ALIAS)) {
+                return Arrays.asList(result, secondResult).iterator();
+            } else {
+                return Collections.emptyIterator();
             }
         });
 
@@ -404,277 +265,6 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         assertTrue(aliasMap.containsKey("child"));
         assertEquals(Collections.singletonList("alias"), aliasMap.get("child"));
         assertEquals(1, detectedConflictingAliases.get());
-    }
-
-    @Test
-    public void test_vanity_path_registration() throws Exception {
-        // specifically making this a weird value because we want to verify that
-        // the configuration value is being used
-        int DEFAULT_VANITY_STATUS = 333333;
-
-        when(resourceResolverFactory.getDefaultVanityPathRedirectStatus()).thenReturn(DEFAULT_VANITY_STATUS);
-
-        final List<Resource> resources = new ArrayList<>();
-
-        Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-        resources.add(justVanityPath);
-
-        Resource badVanityPath = mock(Resource.class, "badVanityPath");
-        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
-        when(badVanityPath.getName()).thenReturn("badVanityPath");
-        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
-        resources.add(badVanityPath);
-
-        Resource redirectingVanityPath = mock(Resource.class, "redirectingVanityPath");
-        when(redirectingVanityPath.getPath()).thenReturn("/redirectingVanityPath");
-        when(redirectingVanityPath.getName()).thenReturn("redirectingVanityPath");
-        when(redirectingVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/redirectingVanityPath", "sling:redirect", true));
-        resources.add(redirectingVanityPath);
-
-        Resource redirectingVanityPath301 = mock(Resource.class, "redirectingVanityPath301");
-        when(redirectingVanityPath301.getPath()).thenReturn("/redirectingVanityPath301");
-        when(redirectingVanityPath301.getName()).thenReturn("redirectingVanityPath301");
-        when(redirectingVanityPath301.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/redirectingVanityPath301", "sling:redirect", true, "sling:redirectStatus", 301));
-        resources.add(redirectingVanityPath301);
-
-        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
-        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
-        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
-
-        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
-        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
-        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
-        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
-        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
-        resources.add(vanityPathOnJcrContent);
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                String query = invocation.getArguments()[0].toString();
-                if (matchesPagedQuery(query)) {
-                    String path = extractStartPath(query);
-                    Collections.sort(resources, vanityResourceComparator);
-                    return resources.stream().filter(e -> getFirstVanityPath(e).compareTo(path) > 0).iterator();
-                } else if (query.contains("sling:vanityPath")) {
-                    return resources.iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        mapEntries.doInit();
-        mapEntries.initializeVanityPaths();
-
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-
-        assertEquals(8, entries.size());
-        for (MapEntry entry : entries) {
-            if (entry.getPattern().contains("/target/redirectingVanityPath301")) {
-                assertEquals(301, entry.getStatus());
-                assertFalse(entry.isInternal());
-            } else if (entry.getPattern().contains("/target/redirectingVanityPath")) {
-                assertEquals(DEFAULT_VANITY_STATUS, entry.getStatus());
-                assertFalse(entry.isInternal());
-            } else if (entry.getPattern().contains("/target/justVanityPath")) {
-                assertTrue(entry.isInternal());
-            } else if (entry.getPattern().contains("/target/vanityPathOnJcrContent")) {
-                for (String redirect : entry.getRedirect()) {
-                    assertFalse(redirect.contains("jcr:content"));
-                }
-            }
-        }
-
-        Field field = MapEntries.class.getDeclaredField("vanityTargets");
-        field.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(4, vanityTargets.size());
-    }
-
-    @Test
-    public void test_vanity_path_updates() throws Exception {
-        Resource parent = mock(Resource.class, "parent");
-        when(parent.getPath()).thenReturn("/foo/parent");
-        when(parent.getName()).thenReturn("parent");
-        when(parent.getValueMap()).thenReturn(new ValueMapDecorator(Collections.<String, Object>emptyMap()));
-        when(resourceResolver.getResource(parent.getPath())).thenReturn(parent);
-
-        Resource child = mock(Resource.class, "jcrcontent");
-        when(child.getPath()).thenReturn("/foo/parent/jcr:content");
-        when(child.getName()).thenReturn("jcr:content");
-        when(child.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found"));
-        when(child.getParent()).thenReturn(parent);
-        when(parent.getChild(child.getName())).thenReturn(child);
-        when(resourceResolver.getResource(child.getPath())).thenReturn(child);
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                return Collections.<Resource> emptySet().iterator();
-            }
-        });
-
-        mapEntries.doInit();
-        mapEntries.initializeVanityPaths();
-
-        // map entries should have no alias atm
-        assertTrue( mapEntries.getResolveMaps().isEmpty());
-
-        // add parent
-        mapEntries.onChange(Arrays.asList(new ResourceChange(ChangeType.ADDED, parent.getPath(), false)));
-        assertTrue( mapEntries.getResolveMaps().isEmpty());
-
-        // add child
-        mapEntries.onChange(Arrays.asList(new ResourceChange(ChangeType.ADDED, child.getPath(), false)));
-
-        // two entries for the vanity path
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-        for (MapEntry entry : entries) {
-            assertTrue(entry.getPattern().contains("/target/found"));
-        }
-
-        // update parent - no change
-        mapEntries.onChange(Arrays.asList(new ResourceChange(ChangeType.CHANGED, parent.getPath(), false)));
-        entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-        for (MapEntry entry : entries) {
-            assertTrue(entry.getPattern().contains("/target/found"));
-        }
-
-        // update child - no change
-        mapEntries.onChange(Arrays.asList(new ResourceChange(ChangeType.CHANGED, child.getPath(), false)));
-        entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-        for (MapEntry entry : entries) {
-            assertTrue(entry.getPattern().contains("/target/found"));
-        }
-
-        // remove child - empty again
-        when(resourceResolver.getResource(child.getPath())).thenReturn(null);
-        when(parent.getChild(child.getName())).thenReturn(null);
-        mapEntries.onChange(Arrays.asList(new ResourceChange(ChangeType.REMOVED, child.getPath(), false)));
-        assertTrue( mapEntries.getResolveMaps().isEmpty());
-
-        // remove parent - still empty
-        when(resourceResolver.getResource(parent.getPath())).thenReturn(null);
-        mapEntries.onChange(Arrays.asList(new ResourceChange(ChangeType.REMOVED, parent.getPath(), false)));
-        assertTrue( mapEntries.getResolveMaps().isEmpty());
-    }
-    
-    @Test
-    public void test_vanity_path_updates_do_not_reload_multiple_times() throws IOException {
-        Resource parent = mock(Resource.class, "parent");
-        when(parent.getPath()).thenReturn("/foo/parent");
-        when(parent.getName()).thenReturn("parent");
-        when(parent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found1"));
-        when(resourceResolver.getResource(parent.getPath())).thenReturn(parent);
-
-        Resource child = mock(Resource.class, "jcrcontent");
-        when(child.getPath()).thenReturn("/foo/parent/jcr:content");
-        when(child.getName()).thenReturn("jcr:content");
-        when(child.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found2"));
-        when(child.getParent()).thenReturn(parent);
-        when(parent.getChild(child.getName())).thenReturn(child);
-        when(resourceResolver.getResource(child.getPath())).thenReturn(child);
-        
-        Resource child2 = mock(Resource.class, "child2");
-        when(child2.getPath()).thenReturn("/foo/parent/child2");
-        when(child2.getName()).thenReturn("child2");
-        when(child2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found3"));
-        when(child2.getParent()).thenReturn(parent);
-        when(parent.getChild(child2.getName())).thenReturn(child2);
-        when(resourceResolver.getResource(child2.getPath())).thenReturn(child2);
-        
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                return Collections.<Resource> emptySet().iterator();
-            }
-        });
-        
-        mapEntries.doInit();
-        mapEntries.initializeVanityPaths();
-
-        // map entries should have no alias atm
-        assertTrue( mapEntries.getResolveMaps().isEmpty());
-        // till now we already have 2 events being sent
-        Mockito.verify(eventAdmin,Mockito.times(2)).postEvent(ArgumentMatchers.any(Event.class));
-
-        // 3 updates at the same onChange call
-        mapEntries.onChange(Arrays.asList(
-                new ResourceChange(ChangeType.ADDED, parent.getPath(), false),
-                new ResourceChange(ChangeType.ADDED, child.getPath(), false),
-                new ResourceChange(ChangeType.ADDED, child2.getPath(), false)
-                ));
-        
-        // 6 entries for the vanity path
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-        assertEquals(6, entries.size());
-        
-        assertTrue(entries.stream().anyMatch(e -> e.getPattern().contains("/target/found1")));
-        assertTrue(entries.stream().anyMatch(e -> e.getPattern().contains("/target/found2")));
-        assertTrue(entries.stream().anyMatch(e -> e.getPattern().contains("/target/found3")));
-        
-        // a single event is sent for all 3 added vanity paths
-        Mockito.verify(eventAdmin,Mockito.times(3)).postEvent(ArgumentMatchers.any(Event.class));
-    }
-
-    @Test
-    public void test_vanity_path_registration_include_exclude() throws IOException {
-        final String[] validPaths = {"/libs/somewhere", "/libs/a/b", "/foo/a", "/baa/a"};
-        final String[] invalidPaths = {"/libs/denied/a", "/libs/denied/b/c", "/nowhere"};
-
-        final List<Resource> resources = new ArrayList<>();
-        for(final String val : validPaths) {
-            resources.add(getVanityPathResource(val));
-        }
-        for(final String val : invalidPaths) {
-            resources.add(getVanityPathResource(val));
-        }
-
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                String query = invocation.getArguments()[0].toString();
-                if (matchesPagedQuery(query)) {
-                    String path = extractStartPath(query);
-                    Collections.sort(resources, vanityResourceComparator);
-                    return resources.stream().filter(e -> getFirstVanityPath(e).compareTo(path) > 0).iterator();
-                } else
-                if (query.contains("sling:vanityPath")) {
-                    return resources.iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        mapEntries.doInit();
-        mapEntries.initializeVanityPaths();
-
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-        // each valid resource results in 2 entries
-        assertEquals(validPaths.length * 2, entries.size());
-
-        final Set<String> resultSet = new HashSet<>();
-        for(final String p : validPaths) {
-            resultSet.add(p + "$1");
-            resultSet.add(p + ".html");
-        }
-        for (final MapEntry entry : entries) {
-            assertTrue(resultSet.remove(entry.getRedirect()[0]));
-        }
     }
 
     @Test
@@ -708,374 +298,6 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         actualContent = (String) method.invoke(mapEntries, mapEntry);
         assertEquals("/content", actualContent);
     }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void test_doAddVanity() throws Exception {
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-        assertEquals(0, entries.size());
-        Field field = MapEntries.class.getDeclaredField("vanityTargets");
-        field.setAccessible(true);
-        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(0, vanityTargets.size());
-
-        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
-        addResource.setAccessible(true);
-
-        Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
-
-        entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-
-        //bad vanity
-        Resource badVanityPath = mock(Resource.class, "badVanityPath");
-        when(resourceResolver.getResource("/badVanityPath")).thenReturn(badVanityPath);
-        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
-        when(badVanityPath.getName()).thenReturn("badVanityPath");
-        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
-
-        addResource.invoke(mapEntries, "/badVanityPath", new AtomicBoolean());
-
-
-        assertEquals(2, entries.size());
-
-        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(1, vanityTargets.size());
-
-        //vanity under jcr:content
-        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
-        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
-        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
-
-        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
-        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
-        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
-        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
-        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
-        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
-
-        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
-
-        entries = mapEntries.getResolveMaps();
-        assertEquals(4, entries.size());
-
-        counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(4, counter.longValue());
-
-        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(2, vanityTargets.size());
-
-        assertNull(vanityTargets.get("/vanityPathOnJcrContent/jcr:content"));
-        assertNotNull(vanityTargets.get("/vanityPathOnJcrContent"));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void test_doAddVanity_1() throws Exception {
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(10L);
-
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-        assertEquals(0, entries.size());
-        Field field = MapEntries.class.getDeclaredField("vanityTargets");
-        field.setAccessible(true);
-        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(0, vanityTargets.size());
-
-        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
-        addResource.setAccessible(true);
-
-        Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
-
-        entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-
-        //bad vanity
-        Resource badVanityPath = mock(Resource.class, "badVanityPath");
-        when(resourceResolver.getResource("/badVanityPath")).thenReturn(badVanityPath);
-        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
-        when(badVanityPath.getName()).thenReturn("badVanityPath");
-        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
-
-        addResource.invoke(mapEntries, "/badVanityPath", new AtomicBoolean());
-
-
-        assertEquals(2, entries.size());
-
-        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(1, vanityTargets.size());
-
-        //vanity under jcr:content
-        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
-        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
-        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
-
-        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
-        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
-        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
-        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
-        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
-        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
-
-        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
-
-        entries = mapEntries.getResolveMaps();
-        assertEquals(4, entries.size());
-
-        counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(4, counter.longValue());
-
-        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(2, vanityTargets.size());
-
-        assertNull(vanityTargets.get("/vanityPathOnJcrContent/jcr:content"));
-        assertNotNull(vanityTargets.get("/vanityPathOnJcrContent"));
-    }
-
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void test_doUpdateVanity() throws Exception {
-        Field field0 = MapEntries.class.getDeclaredField("resolveMapsMap");
-        field0.setAccessible(true);
-        Map<String, List<MapEntry>> resolveMapsMap = (Map<String, List<MapEntry>>) field0.get(mapEntries);
-        assertEquals(1, resolveMapsMap.size());
-
-        Field field = MapEntries.class.getDeclaredField("vanityTargets");
-        field.setAccessible(true);
-        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(0, vanityTargets.size());
-
-        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
-        addResource.setAccessible(true);
-
-        final Method updateResource = MapEntries.class.getDeclaredMethod("updateResource", String.class, AtomicBoolean.class);
-        updateResource.setAccessible(true);
-
-        Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
-
-        assertEquals(2, resolveMapsMap.size());
-        assertEquals(1, vanityTargets.size());
-        assertNotNull(resolveMapsMap.get("/target/justVanityPath"));
-        assertNull(resolveMapsMap.get("/target/justVanityPathUpdated"));
-        assertEquals(1, vanityTargets.get("/justVanityPath").size());
-        assertEquals("/target/justVanityPath", vanityTargets.get("/justVanityPath").get(0));
-
-        //update vanity path
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPathUpdated"));
-        updateResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
-
-        assertEquals(2, resolveMapsMap.size());
-        assertEquals(1, vanityTargets.size());
-        assertNull(resolveMapsMap.get("/target/justVanityPath"));
-        assertNotNull(resolveMapsMap.get("/target/justVanityPathUpdated"));
-        assertEquals(1, vanityTargets.get("/justVanityPath").size());
-        assertEquals("/target/justVanityPathUpdated", vanityTargets.get("/justVanityPath").get(0));
-
-        //vanity under jcr:content
-        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
-        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
-        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
-        when(vanityPathOnJcrContentParent.getValueMap()).thenReturn(buildValueMap());
-
-        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
-        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
-        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
-        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
-        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
-        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
-
-        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
-
-        assertEquals(3, resolveMapsMap.size());
-        assertEquals(2, vanityTargets.size());
-        assertNotNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
-        assertNull(resolveMapsMap.get("/target/vanityPathOnJcrContentUpdated"));
-        assertEquals(1, vanityTargets.get("/vanityPathOnJcrContent").size());
-        assertEquals("/target/vanityPathOnJcrContent", vanityTargets.get("/vanityPathOnJcrContent").get(0));
-
-        //update vanity path
-        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContentUpdated"));
-        updateResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
-
-        assertEquals(3, resolveMapsMap.size());
-        assertEquals(2, vanityTargets.size());
-        assertNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
-        assertNotNull(resolveMapsMap.get("/target/vanityPathOnJcrContentUpdated"));
-        assertEquals(1, vanityTargets.get("/vanityPathOnJcrContent").size());
-        assertEquals("/target/vanityPathOnJcrContentUpdated", vanityTargets.get("/vanityPathOnJcrContent").get(0));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void test_doRemoveVanity() throws Exception {
-        Field field0 = MapEntries.class.getDeclaredField("resolveMapsMap");
-        field0.setAccessible(true);
-        Map<String, List<MapEntry>> resolveMapsMap = (Map<String, List<MapEntry>>) field0.get(mapEntries);
-        assertEquals(1, resolveMapsMap.size());
-
-        Field field = MapEntries.class.getDeclaredField("vanityTargets");
-        field.setAccessible(true);
-        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(0, vanityTargets.size());
-
-        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
-        addResource.setAccessible(true);
-
-        Method method1 = MapEntries.class.getDeclaredMethod("doRemoveVanity", String.class);
-        method1.setAccessible(true);
-
-        Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-        assertEquals(2, resolveMapsMap.size());
-        assertEquals(1, vanityTargets.size());
-        assertNotNull(resolveMapsMap.get("/target/justVanityPath"));
-        assertEquals(1, vanityTargets.get("/justVanityPath").size());
-        assertEquals("/target/justVanityPath", vanityTargets.get("/justVanityPath").get(0));
-
-        //remove vanity path
-        method1.invoke(mapEntries, "/justVanityPath");
-
-        counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(0, counter.longValue());
-
-        assertEquals(1, resolveMapsMap.size());
-        assertEquals(0, vanityTargets.size());
-        assertNull(resolveMapsMap.get("/target/justVanityPath"));
-
-        //vanity under jcr:content
-        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
-        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
-        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
-
-        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
-        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
-        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
-        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
-        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
-        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
-
-        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
-
-        assertEquals(2, resolveMapsMap.size());
-        assertEquals(1, vanityTargets.size());
-        assertNotNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
-        assertEquals(1,vanityTargets.get("/vanityPathOnJcrContent").size());
-        assertEquals("/target/vanityPathOnJcrContent", vanityTargets.get("/vanityPathOnJcrContent").get(0));
-
-        //remove vanity path
-        method1.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content");
-
-        assertEquals(1, resolveMapsMap.size());
-        assertEquals(0, vanityTargets.size());
-        assertNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
-
-    }
-/*
-    @SuppressWarnings("unchecked")
-    @Test
-    public void test_doUpdateVanityOrder() throws Exception {
-        Field field0 = MapEntries.class.getDeclaredField("resolveMapsMap");
-        field0.setAccessible(true);
-        Map<String, List<MapEntry>> resolveMapsMap = (Map<String, List<MapEntry>>) field0.get(mapEntries);
-        assertEquals(1, resolveMapsMap.size());
-
-        Field field = MapEntries.class.getDeclaredField("vanityTargets");
-        field.setAccessible(true);
-        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
-        assertEquals(0, vanityTargets.size());
-
-        Method method = MapEntries.class.getDeclaredMethod("doAddVanity", String.class);
-        method.setAccessible(true);
-
-        Method method1 = MapEntries.class.getDeclaredMethod("doUpdateVanityOrder", String.class, boolean.class);
-        method1.setAccessible(true);
-
-        Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        method.invoke(mapEntries, "/justVanityPath");
-
-        Resource justVanityPath2 = mock(Resource.class, "justVanityPath2");
-        when(resourceResolver.getResource("/justVanityPath2")).thenReturn(justVanityPath2);
-        when(justVanityPath2.getPath()).thenReturn("/justVanityPath2");
-        when(justVanityPath2.getName()).thenReturn("justVanityPath2");
-        when(justVanityPath2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 100));
-
-        method.invoke(mapEntries, "/justVanityPath2");
-
-        assertEquals(2, resolveMapsMap.size());
-        assertEquals(2, vanityTargets.size());
-        assertNotNull(resolveMapsMap.get("/target/justVanityPath"));
-
-        Iterator <MapEntry> iterator = resolveMapsMap.get("/target/justVanityPath").iterator();
-        assertEquals("/justVanityPath2$1", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath$1", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath2.html", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath.html", iterator.next().getRedirect()[0]);
-        assertFalse(iterator.hasNext());
-
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 1000));
-        method1.invoke(mapEntries, "/justVanityPath",false);
-
-        iterator = resolveMapsMap.get("/target/justVanityPath").iterator();
-        assertEquals("/justVanityPath$1", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath2$1", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath.html", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath2.html", iterator.next().getRedirect()[0]);
-        assertFalse(iterator.hasNext());
-
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-        method1.invoke(mapEntries, "/justVanityPath",true);
-
-        iterator = resolveMapsMap.get("/target/justVanityPath").iterator();
-        assertEquals("/justVanityPath2$1", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath$1", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath2.html", iterator.next().getRedirect()[0]);
-        assertEquals("/justVanityPath.html", iterator.next().getRedirect()[0]);
-        assertFalse(iterator.hasNext());
-    }
-*/
 
     //SLING-3727
     @Test
@@ -1129,7 +351,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
     //SLING-3727
     @Test
-    public void test_doRemoveAttributessWithDisableAliasOptimization() throws Exception {
+    public void test_doRemoveAttributesWithDisableAliasOptimization() throws Exception {
         final Method removeAlias = MapEntries.class.getDeclaredMethod("removeAlias", String.class, String.class, AtomicBoolean.class);
         removeAlias.setAccessible(true);
 
@@ -1178,7 +400,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
         assertEquals(1, aliasMap.size());
 
-        //test_that_duplicate_alias_doesnt_replace_first_alias
+        //test_that_duplicate_alias_does_not_replace_first_alias
         final Resource secondResult = mock(Resource.class);
         when(resourceResolver.getResource("/parent/child2")).thenReturn(secondResult);
         when(secondResult.getParent()).thenReturn(parent);
@@ -1240,7 +462,7 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
 
         assertEquals(1, aliasMap.size());
 
-        //test_that_duplicate_alias_doesnt_replace_first_alias
+        //test_that_duplicate_alias_does_not_replace_first_alias
         final Resource secondResult = mock(Resource.class);
         when(resourceResolver.getResource("/parent2")).thenReturn(secondResult);
         when(secondResult.getParent()).thenReturn(parent);
@@ -1536,7 +758,6 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         assertEquals(0, aliasMap.size());
     }
 
-    
     @Test
     public void test_doRemoveAlias3() throws Exception {
         final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
@@ -1972,16 +1193,6 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
     }
 
     @Test
-    public void test_isValidVanityPath() throws Exception {
-        Method method = MapEntries.class.getDeclaredMethod("isValidVanityPath", String.class);
-        method.setAccessible(true);
-
-        assertFalse((Boolean)method.invoke(mapEntries, "/jcr:system/node"));
-
-        assertTrue((Boolean)method.invoke(mapEntries, "/justVanityPath"));
-    }
-
-    @Test
     //SLING-4847
     public void test_doNodeAdded1() throws Exception {
         final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
@@ -1989,371 +1200,6 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         final AtomicBoolean refreshed = new AtomicBoolean(false);
         addResource.invoke(mapEntries, "/node", refreshed);
         assertTrue(refreshed.get());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_getVanityPaths_1() throws Exception {
-
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
-
-        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, "/notExisting");
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(0, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_getVanityPaths_2() throws Exception {
-
-        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
-
-        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-
-        final Resource justVanityPath2 = mock(Resource.class, "justVanityPath2");
-        when(resourceResolver.getResource("/justVanityPath2")).thenReturn(justVanityPath2);
-        when(justVanityPath2.getPath()).thenReturn("/justVanityPath2");
-        when(justVanityPath2.getName()).thenReturn("justVanityPath2");
-        when(justVanityPath2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 100));
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(4, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_getVanityPaths_3() throws Exception {
-
-        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
-        when(this.resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(false);
-
-        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(0, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_getVanityPaths_4() throws Exception {
-
-        final Resource badVanityPath = mock(Resource.class, "badVanityPath");
-        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
-        when(badVanityPath.getName()).thenReturn("badVanityPath");
-        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
-
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(badVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
-        when(this.resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(true);
-
-        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, "/content/mypage/en-us-{132");
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(0, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_getVanityPaths_5() throws Exception {
-
-        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(2L);
-        when(this.resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(false);
-
-        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-
-        final Resource justVanityPath2 = mock(Resource.class, "justVanityPath2");
-        when(resourceResolver.getResource("/justVanityPath2")).thenReturn(justVanityPath2);
-        when(justVanityPath2.getPath()).thenReturn("/justVanityPath2");
-        when(justVanityPath2.getName()).thenReturn("justVanityPath2");
-        when(justVanityPath2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 100));
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_loadVanityPaths() throws Exception {
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(2L);
-
-        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        Method method = MapEntries.class.getDeclaredMethod("loadVanityPaths", ResourceResolver.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, resourceResolver);
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_loadVanityPaths_1() throws Exception {
-
-        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-        Method method = MapEntries.class.getDeclaredMethod("loadVanityPaths", ResourceResolver.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, resourceResolver);
-
-        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-    }
-
-    @Test
-    //SLING-4891
-    public void test_getMapEntryList() throws Exception {
-
-        List<MapEntry> entries = mapEntries.getResolveMaps();
-        assertEquals(0, entries.size());
-
-
-        final Resource justVanityPath = mock(Resource.class,
-                "justVanityPath");
-
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath",
-                "/target/justVanityPath"));
-
-        when(resourceResolver.findResources(anyString(),
-                eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-                    @Override
-                    public Iterator<Resource> answer(InvocationOnMock invocation)
-                            throws Throwable {
-                        if
-                        (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                            return Collections.singleton(justVanityPath).iterator();
-                        } else {
-                            return Collections.<Resource> emptySet().iterator();
-                        }
-                    }
-                });
-
-        Method method =
-                MapEntries.class.getDeclaredMethod("getMapEntryList",String.class);
-        method.setAccessible(true);
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-
-        Field vanityCounter =
-                MapEntries.class.getDeclaredField("vanityCounter");
-        vanityCounter.setAccessible(true);
-        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-
-        method.invoke(mapEntries, "/target/justVanityPath");
-
-        entries = mapEntries.getResolveMaps();
-        assertEquals(2, entries.size());
-
-        counter = (AtomicLong) vanityCounter.get(mapEntries);
-        assertEquals(2, counter.longValue());
-    }
-
-    @Test
-    //SLING-4883
-    public void test_concutrrent_getResolveMapsIterator() throws Exception {
-        ExecutorService pool = Executors.newFixedThreadPool(10);
-
-        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
-        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
-        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
-        when(justVanityPath.getName()).thenReturn("justVanityPath");
-        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
-
-
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
-                    return Collections.singleton(justVanityPath).iterator();
-                } else {
-                    return Collections.<Resource> emptySet().iterator();
-                }
-            }
-        });
-
-
-        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(2L);
-
-        ArrayList<DataFuture> list = new ArrayList<>();
-        for (int i =0;i<10;i++) {
-            list.add(createDataFuture(pool, mapEntries));
-
-        }
-
-       for (DataFuture df : list) {
-           df.future.get();
-        }
-
     }
 
     // tests SLING-6542
@@ -2371,23 +1217,13 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         // simulate somewhat slow (1ms) session operations that use locking
         // to determine that they are using the session exclusively.
         // if that lock mechanism detects concurrent access we fail
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                simulateSomewhatSlowSessionOperation(sessionLock);
-                return null;
-            }
-
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            simulateSomewhatSlowSessionOperation(sessionLock);
+            return null;
         }).when(resourceResolver).refresh();
-        Mockito.doAnswer(new Answer<Resource>() {
-
-            @Override
-            public Resource answer(InvocationOnMock invocation) throws Throwable {
-                simulateSomewhatSlowSessionOperation(sessionLock);
-                return null;
-            }
-
+        Mockito.doAnswer((Answer<Resource>) invocation -> {
+            simulateSomewhatSlowSessionOperation(sessionLock);
+            return null;
         }).when(resourceResolver).getResource(any(String.class));
 
         when(resourceResolverFactory.isMapConfiguration(any(String.class))).thenReturn(true);
@@ -2399,26 +1235,22 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
         final Random random = new Random(12321);
         for(int i=0; i<NUM_THREADS; i++) {
             final int randomWait = random.nextInt(10);
-            Runnable r = new Runnable() {
-
-                @Override
-                public void run() {
-                    try{
-                        Thread.sleep(randomWait);
-                        for(int i=0; i<3; i++) {
-                            addResource.invoke(mapEntries, "/node", new AtomicBoolean());
-                            updateResource.invoke(mapEntries, "/node", new AtomicBoolean());
-                            handleConfigurationUpdate.invoke(mapEntries, "/node", new AtomicBoolean(), new AtomicBoolean(), false);
-                        }
-                    } catch(Exception e) {
-                        e.printStackTrace();
-                        synchronized(exceptions) {
-                            exceptions.add(e);
-                        }
-                        failureCnt.incrementAndGet();
-                    } finally {
-                        done.release();
+            Runnable r = () -> {
+                try{
+                    Thread.sleep(randomWait);
+                    for(int i1 = 0; i1 <3; i1++) {
+                        addResource.invoke(mapEntries, "/node", new AtomicBoolean());
+                        updateResource.invoke(mapEntries, "/node", new AtomicBoolean());
+                        handleConfigurationUpdate.invoke(mapEntries, "/node", new AtomicBoolean(), new AtomicBoolean(), false);
                     }
+                } catch(Exception e) {
+                    // e.printStackTrace();
+                    synchronized(exceptions) {
+                        exceptions.add(e);
+                    }
+                    failureCnt.incrementAndGet();
+                } finally {
+                    done.release();
                 }
             };
             Thread th = new Thread(r);
@@ -2437,53 +1269,12 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
     public void testLoadAliases_ValidAbsolutePath_DefaultPaths() {
         when(resourceResolverFactory.getAllowedAliasLocations()).thenReturn(Collections.emptySet());
 
-        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer(new Answer<Iterator<Resource>>() {
-            @Override
-            public Iterator<Resource> answer(InvocationOnMock invocation) throws Throwable {
-                String query = StringUtils.trim((String)invocation.getArguments()[0]);
-                assertEquals("SELECT [sling:alias] FROM [nt:base] WHERE NOT isdescendantnode('/jcr:system') AND [sling:alias] IS NOT NULL AND FIRST([sling:alias]) >= '' ORDER BY FIRST([sling:alias])", query);
-                return Collections.<Resource> emptySet().iterator();
-            }
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            String query = StringUtils.trim((String)invocation.getArguments()[0]);
+            assertEquals("SELECT [sling:alias] FROM [nt:base] WHERE NOT isdescendantnode('/jcr:system') AND [sling:alias] IS NOT NULL AND FIRST([sling:alias]) >= '' ORDER BY FIRST([sling:alias])", query);
+            return Collections.emptyIterator();
         });
 
         mapEntries.doInit();
     }
-
-    @Test
-    public void test_vanitypath_disabled() throws Exception {
-        // initialize with having vanity path disabled - must not throw errors here or on disposal
-        when(resourceResolverFactory.isVanityPathEnabled()).thenReturn(false);
-
-        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
-
-        mapEntries.doInit();
-    }
-
-    // utilities for testing vanity path queries
-
-    private static String VPQSTART = "SELECT [sling:vanityPath], [sling:redirect], [sling:redirectStatus] FROM [nt:base] WHERE NOT isdescendantnode('/jcr:system') AND [sling:vanityPath] IS NOT NULL AND FIRST([sling:vanityPath]) >= '";
-    private static String VPQEND = "' ORDER BY FIRST([sling:vanityPath])";
-
-    private boolean matchesPagedQuery(String query) {
-        return query.startsWith(VPQSTART) && query.endsWith(VPQEND);
-    }
-
-    private String extractStartPath(String query) {
-        String remainder = query.substring(VPQSTART.length());
-        return remainder.substring(0, remainder.length() - VPQEND.length());
-    }
-
-    private String getFirstVanityPath(Resource r) {
-        String vp[] = r.getValueMap().get("sling:vanityPath", new String[0]);
-        return vp.length == 0 ? "": vp[0];
-    }
-
-    private Comparator<Resource> vanityResourceComparator = new Comparator<Resource>() {
-        @Override
-        public int compare(Resource o1, Resource o2) {
-            String s1 = getFirstVanityPath(o1);
-            String s2 = getFirstVanityPath(o2);
-            return s1.compareTo(s2);
-        }
-    };
 }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathMapEntriesTest.java
@@ -1,0 +1,1256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.resourceresolver.impl.mapping;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChange.ChangeType;
+import org.apache.sling.api.resource.path.Path;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
+import org.apache.sling.resourceresolver.impl.mapping.MapConfigurationProvider.VanityPathConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventAdmin;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class VanityPathMapEntriesTest extends AbstractMappingMapEntriesTest {
+
+    private MapEntries mapEntries;
+
+    @Mock
+    private MapConfigurationProvider resourceResolverFactory;
+
+    @Mock
+    private BundleContext bundleContext;
+
+    @Mock
+    private Bundle bundle;
+
+    @Mock
+    private ResourceResolver resourceResolver;
+
+    @Mock
+    private EventAdmin eventAdmin;
+
+    private int pageSize;
+    private int prevPageSize = 1000;
+
+    @Parameters(name = "page size -> {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] { { 1 }, { 1000 } });
+    }
+
+    public VanityPathMapEntriesTest(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked" })
+    @Before
+    public void setup() throws Exception {
+        prevPageSize = Integer.getInteger("sling.vanityPath.pageSize", 2000);
+        System.setProperty("sling.vanityPath.pageSize", Integer.toString(pageSize));
+
+        MockitoAnnotations.openMocks(this);
+
+        final List<VanityPathConfig> configs = new ArrayList<>();
+        configs.add(new VanityPathConfig("/libs/", false));
+        configs.add(new VanityPathConfig("/libs/denied", true));
+        configs.add(new VanityPathConfig("/foo/", false));
+        configs.add(new VanityPathConfig("/baa/", false));
+        configs.add(new VanityPathConfig("/justVanityPath", false));
+        configs.add(new VanityPathConfig("/justVanityPath2", false));
+        configs.add(new VanityPathConfig("/badVanityPath", false));
+        configs.add(new VanityPathConfig("/redirectingVanityPath", false));
+        configs.add(new VanityPathConfig("/redirectingVanityPath301", false));
+        configs.add(new VanityPathConfig("/vanityPathOnJcrContent", false));
+
+        Collections.sort(configs);
+        when(bundle.getSymbolicName()).thenReturn("TESTBUNDLE");
+        when(bundleContext.getBundle()).thenReturn(bundle);
+        when(resourceResolverFactory.getServiceResourceResolver(any(Map.class))).thenReturn(resourceResolver);
+        when(resourceResolverFactory.isVanityPathEnabled()).thenReturn(true);
+        when(resourceResolverFactory.getVanityPathConfig()).thenReturn(configs);
+        when(resourceResolverFactory.isOptimizeAliasResolutionEnabled()).thenReturn(true);
+        when(resourceResolverFactory.getObservationPaths()).thenReturn(new Path[] {new Path("/")});
+        when(resourceResolverFactory.getMapRoot()).thenReturn(MapEntries.DEFAULT_MAP_ROOT);
+        when(resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(-1L);
+        when(resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(true);
+        when(resourceResolver.findResources(anyString(), eq("sql"))).thenReturn(
+                Collections.emptyIterator());
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenReturn(
+                Collections.emptyIterator());
+        when(resourceResolverFactory.getAllowedAliasLocations()).thenReturn(Collections.emptySet());
+
+        Optional<ResourceResolverMetrics> metrics = Optional.empty();
+
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
+    }
+
+    @Override
+    @After
+    public void tearDown() {
+        System.setProperty("sling.vanityPath.pageSize", Integer.toString(prevPageSize));
+        mapEntries.dispose();
+    }
+
+    @Test
+    public void test_simple_vanity_path() throws IOException {
+        String vanityPath = "/xyz";
+        String containerName = "foo";
+        String childName = "child";
+        String oneMore = "one-more";
+        prepareMapEntriesForVanityPath(false, false, containerName,
+                childName, oneMore, vanityPath);
+        mapEntries.doInit();
+        mapEntries.initializeVanityPaths();
+        Map<String, List<String>> vanityMap = mapEntries.getVanityPathMappings();
+        assertNotNull(vanityMap);
+        assertEquals(vanityPath, vanityMap.get("/" + containerName + "/" + childName).get(0));
+        assertEquals(2, vanityMap.size());
+        assertNotNull(vanityMap.get("/" + containerName + "/" + oneMore));
+    }
+
+    // see SLING-12620
+    @Test
+    public void test_simple_vanity_path_support_with_null_parent() throws IOException {
+        String vanityPath = "/xyz";
+        String containerName = "foo";
+        String childName = "child";
+        String oneMore = "one-more";
+        prepareMapEntriesForVanityPath(true, true, containerName,
+                childName, oneMore, vanityPath);
+        mapEntries.doInit();
+        mapEntries.initializeVanityPaths();
+        Map<String, List<String>> vanityMap = mapEntries.getVanityPathMappings();
+        assertNotNull(vanityMap);
+        // not present
+        assertNull(vanityMap.get("/" + containerName + "/" + childName));
+        assertNull(vanityMap.get("/" + containerName + "/" + childName + "/jcr:content"));
+        // but the other one is present
+        assertEquals(1, vanityMap.size());
+        assertNotNull(vanityMap.get("/" + containerName + "/" + oneMore));
+    }
+
+    // create a 'custom' node (two flags), followed by a hardwired one (this is used to check that vanity path
+    // processing does not abort after the first error
+    private void prepareMapEntriesForVanityPath(boolean onJcrContent, boolean withNullParent,
+                                                String containerName, String childName,
+                                                String additionalChildName, String vanityPath) {
+
+        final Resource parent = mock(Resource.class);
+
+        when(parent.getParent()).thenReturn(null);
+        when(parent.getPath()).thenReturn("/" + containerName);
+        when(parent.getName()).thenReturn(containerName);
+
+        final Resource vanity = mock(Resource.class);
+
+        when(vanity.getParent()).thenReturn(withNullParent && !onJcrContent ? null : parent);
+        when(vanity.getPath()).thenReturn("/" + containerName + "/" + childName);
+        when(vanity.getName()).thenReturn(childName);
+
+        final Resource content = mock(Resource.class);
+
+        when(content.getParent()).thenReturn(withNullParent && onJcrContent ? null : vanity);
+        when(content.getPath()).thenReturn("/" + containerName + "/" + childName + "/jcr:content");
+        when(content.getName()).thenReturn("jcr:content");
+
+        final Resource oneMore = mock(Resource.class);
+
+        when(oneMore.getParent()).thenReturn(parent);
+        when(oneMore.getPath()).thenReturn("/" + containerName + "/" + additionalChildName);
+        when(oneMore.getName()).thenReturn(additionalChildName);
+
+        when(oneMore.getValueMap()).thenReturn(buildValueMap(MapEntries.PROP_VANITY_PATH, vanityPath + "/onemore"));
+
+        final Resource vanityPropHolder = onJcrContent ? content : vanity;
+
+        when(vanityPropHolder.getValueMap()).thenReturn(buildValueMap(MapEntries.PROP_VANITY_PATH, vanityPath));
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains(MapEntries.PROP_VANITY_PATH)) {
+                return List.of(vanityPropHolder, oneMore).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+    }
+
+    @Test
+    public void test_vanity_path_registration() throws Exception {
+        // specifically making this a weird value because we want to verify that
+        // the configuration value is being used
+        int DEFAULT_VANITY_STATUS = 333333;
+
+        when(resourceResolverFactory.getDefaultVanityPathRedirectStatus()).thenReturn(DEFAULT_VANITY_STATUS);
+
+        final List<Resource> resources = new ArrayList<>();
+
+        Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+        resources.add(justVanityPath);
+
+        Resource badVanityPath = mock(Resource.class, "badVanityPath");
+        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
+        when(badVanityPath.getName()).thenReturn("badVanityPath");
+        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
+        resources.add(badVanityPath);
+
+        Resource redirectingVanityPath = mock(Resource.class, "redirectingVanityPath");
+        when(redirectingVanityPath.getPath()).thenReturn("/redirectingVanityPath");
+        when(redirectingVanityPath.getName()).thenReturn("redirectingVanityPath");
+        when(redirectingVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/redirectingVanityPath", "sling:redirect", true));
+        resources.add(redirectingVanityPath);
+
+        Resource redirectingVanityPath301 = mock(Resource.class, "redirectingVanityPath301");
+        when(redirectingVanityPath301.getPath()).thenReturn("/redirectingVanityPath301");
+        when(redirectingVanityPath301.getName()).thenReturn("redirectingVanityPath301");
+        when(redirectingVanityPath301.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/redirectingVanityPath301", "sling:redirect", true, "sling:redirectStatus", 301));
+        resources.add(redirectingVanityPath301);
+
+        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
+        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
+        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
+
+        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
+        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
+        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
+        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
+        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
+        resources.add(vanityPathOnJcrContent);
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            String query = invocation.getArguments()[0].toString();
+            if (matchesPagedQuery(query)) {
+                String path = extractStartPath(query);
+                resources.sort(vanityResourceComparator);
+                return resources.stream().filter(e -> getFirstVanityPath(e).compareTo(path) > 0).iterator();
+            } else if (query.contains("sling:vanityPath")) {
+                return resources.iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        mapEntries.doInit();
+        mapEntries.initializeVanityPaths();
+
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+
+        assertEquals(8, entries.size());
+        for (MapEntry entry : entries) {
+            if (entry.getPattern().contains("/target/redirectingVanityPath301")) {
+                assertEquals(301, entry.getStatus());
+                assertFalse(entry.isInternal());
+            } else if (entry.getPattern().contains("/target/redirectingVanityPath")) {
+                assertEquals(DEFAULT_VANITY_STATUS, entry.getStatus());
+                assertFalse(entry.isInternal());
+            } else if (entry.getPattern().contains("/target/justVanityPath")) {
+                assertTrue(entry.isInternal());
+            } else if (entry.getPattern().contains("/target/vanityPathOnJcrContent")) {
+                for (String redirect : entry.getRedirect()) {
+                    assertFalse(redirect.contains("jcr:content"));
+                }
+            }
+        }
+
+        Field field = MapEntries.class.getDeclaredField("vanityTargets");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(4, vanityTargets.size());
+    }
+
+    @Test
+    public void test_vanity_path_updates() throws Exception {
+        Resource parent = mock(Resource.class, "parent");
+        when(parent.getPath()).thenReturn("/foo/parent");
+        when(parent.getName()).thenReturn("parent");
+        when(parent.getValueMap()).thenReturn(new ValueMapDecorator(Collections.emptyMap()));
+        when(resourceResolver.getResource(parent.getPath())).thenReturn(parent);
+
+        Resource child = mock(Resource.class, "jcrcontent");
+        when(child.getPath()).thenReturn("/foo/parent/jcr:content");
+        when(child.getName()).thenReturn("jcr:content");
+        when(child.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found"));
+        when(child.getParent()).thenReturn(parent);
+        when(parent.getChild(child.getName())).thenReturn(child);
+        when(resourceResolver.getResource(child.getPath())).thenReturn(child);
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> Collections.emptyIterator());
+
+        mapEntries.doInit();
+        mapEntries.initializeVanityPaths();
+
+        // map entries should have no alias atm
+        assertTrue( mapEntries.getResolveMaps().isEmpty());
+
+        // add parent
+        mapEntries.onChange(List.of(new ResourceChange(ChangeType.ADDED, parent.getPath(), false)));
+        assertTrue( mapEntries.getResolveMaps().isEmpty());
+
+        // add child
+        mapEntries.onChange(List.of(new ResourceChange(ChangeType.ADDED, child.getPath(), false)));
+
+        // two entries for the vanity path
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+        for (MapEntry entry : entries) {
+            assertTrue(entry.getPattern().contains("/target/found"));
+        }
+
+        // update parent - no change
+        mapEntries.onChange(List.of(new ResourceChange(ChangeType.CHANGED, parent.getPath(), false)));
+        entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+        for (MapEntry entry : entries) {
+            assertTrue(entry.getPattern().contains("/target/found"));
+        }
+
+        // update child - no change
+        mapEntries.onChange(List.of(new ResourceChange(ChangeType.CHANGED, child.getPath(), false)));
+        entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+        for (MapEntry entry : entries) {
+            assertTrue(entry.getPattern().contains("/target/found"));
+        }
+
+        // remove child - empty again
+        when(resourceResolver.getResource(child.getPath())).thenReturn(null);
+        when(parent.getChild(child.getName())).thenReturn(null);
+        mapEntries.onChange(List.of(new ResourceChange(ChangeType.REMOVED, child.getPath(), false)));
+        assertTrue( mapEntries.getResolveMaps().isEmpty());
+
+        // remove parent - still empty
+        when(resourceResolver.getResource(parent.getPath())).thenReturn(null);
+        mapEntries.onChange(List.of(new ResourceChange(ChangeType.REMOVED, parent.getPath(), false)));
+        assertTrue( mapEntries.getResolveMaps().isEmpty());
+    }
+
+    @Test
+    public void test_vanity_path_updates_do_not_reload_multiple_times() throws IOException {
+        Resource parent = mock(Resource.class, "parent");
+        when(parent.getPath()).thenReturn("/foo/parent");
+        when(parent.getName()).thenReturn("parent");
+        when(parent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found1"));
+        when(resourceResolver.getResource(parent.getPath())).thenReturn(parent);
+
+        Resource child = mock(Resource.class, "jcrcontent");
+        when(child.getPath()).thenReturn("/foo/parent/jcr:content");
+        when(child.getName()).thenReturn("jcr:content");
+        when(child.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found2"));
+        when(child.getParent()).thenReturn(parent);
+        when(parent.getChild(child.getName())).thenReturn(child);
+        when(resourceResolver.getResource(child.getPath())).thenReturn(child);
+
+        Resource child2 = mock(Resource.class, "child2");
+        when(child2.getPath()).thenReturn("/foo/parent/child2");
+        when(child2.getName()).thenReturn("child2");
+        when(child2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/found3"));
+        when(child2.getParent()).thenReturn(parent);
+        when(parent.getChild(child2.getName())).thenReturn(child2);
+        when(resourceResolver.getResource(child2.getPath())).thenReturn(child2);
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> Collections.emptyIterator());
+
+        mapEntries.doInit();
+        mapEntries.initializeVanityPaths();
+
+        // map entries should have no alias atm
+        assertTrue( mapEntries.getResolveMaps().isEmpty());
+        // till now, we already have 2 events being sent
+        Mockito.verify(eventAdmin,Mockito.times(2)).postEvent(ArgumentMatchers.any(Event.class));
+
+        // 3 updates at the same onChange call
+        mapEntries.onChange(Arrays.asList(
+                new ResourceChange(ChangeType.ADDED, parent.getPath(), false),
+                new ResourceChange(ChangeType.ADDED, child.getPath(), false),
+                new ResourceChange(ChangeType.ADDED, child2.getPath(), false)
+                ));
+
+        // 6 entries for the vanity path
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+        assertEquals(6, entries.size());
+
+        assertTrue(entries.stream().anyMatch(e -> e.getPattern().contains("/target/found1")));
+        assertTrue(entries.stream().anyMatch(e -> e.getPattern().contains("/target/found2")));
+        assertTrue(entries.stream().anyMatch(e -> e.getPattern().contains("/target/found3")));
+
+        // a single event is sent for all 3 added vanity paths
+        Mockito.verify(eventAdmin,Mockito.times(3)).postEvent(ArgumentMatchers.any(Event.class));
+    }
+
+    @Test
+    public void test_vanity_path_registration_include_exclude() throws IOException {
+        final String[] validPaths = {"/libs/somewhere", "/libs/a/b", "/foo/a", "/baa/a"};
+        final String[] invalidPaths = {"/libs/denied/a", "/libs/denied/b/c", "/nowhere"};
+
+        final List<Resource> resources = new ArrayList<>();
+        for(final String val : validPaths) {
+            resources.add(getVanityPathResource(val));
+        }
+        for(final String val : invalidPaths) {
+            resources.add(getVanityPathResource(val));
+        }
+
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            String query = invocation.getArguments()[0].toString();
+            if (matchesPagedQuery(query)) {
+                String path = extractStartPath(query);
+                resources.sort(vanityResourceComparator);
+                return resources.stream().filter(e -> getFirstVanityPath(e).compareTo(path) > 0).iterator();
+            } else
+            if (query.contains("sling:vanityPath")) {
+                return resources.iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        mapEntries.doInit();
+        mapEntries.initializeVanityPaths();
+
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+        // each valid resource results in 2 entries
+        assertEquals(validPaths.length * 2, entries.size());
+
+        final Set<String> resultSet = new HashSet<>();
+        for(final String p : validPaths) {
+            resultSet.add(p + "$1");
+            resultSet.add(p + ".html");
+        }
+        for (final MapEntry entry : entries) {
+            assertTrue(resultSet.remove(entry.getRedirect()[0]));
+        }
+    }
+
+    @Test
+    public void test_getActualContentPath() throws Exception {
+
+        Method method = MapEntries.class.getDeclaredMethod("getActualContentPath", String.class);
+        method.setAccessible(true);
+
+        String actualContent = (String) method.invoke(mapEntries, "/content");
+        assertEquals("/content", actualContent);
+
+        actualContent = (String) method.invoke(mapEntries, "/content/jcr:content");
+        assertEquals("/content", actualContent);
+    }
+
+    @Test
+    public void test_getMapEntryRedirect() throws Exception {
+
+        Method method = MapEntries.class.getDeclaredMethod("getMapEntryRedirect", MapEntry.class);
+        method.setAccessible(true);
+
+        MapEntry mapEntry = new MapEntry("/content", -1, false, 0, "/content");
+        String actualContent = (String) method.invoke(mapEntries, mapEntry);
+        assertEquals("/content", actualContent);
+
+        mapEntry = new MapEntry("/content", -1, false, 0, "/content$1");
+        actualContent = (String) method.invoke(mapEntries, mapEntry);
+        assertEquals("/content", actualContent);
+
+        mapEntry = new MapEntry("/content", -1, false, 0, "/content.html");
+        actualContent = (String) method.invoke(mapEntries, mapEntry);
+        assertEquals("/content", actualContent);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_doAddVanity() throws Exception {
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+        assertEquals(0, entries.size());
+        Field field = MapEntries.class.getDeclaredField("vanityTargets");
+        field.setAccessible(true);
+        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(0, vanityTargets.size());
+
+        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
+        addResource.setAccessible(true);
+
+        Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
+
+        entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+
+        //bad vanity
+        Resource badVanityPath = mock(Resource.class, "badVanityPath");
+        when(resourceResolver.getResource("/badVanityPath")).thenReturn(badVanityPath);
+        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
+        when(badVanityPath.getName()).thenReturn("badVanityPath");
+        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
+
+        addResource.invoke(mapEntries, "/badVanityPath", new AtomicBoolean());
+
+
+        assertEquals(2, entries.size());
+
+        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(1, vanityTargets.size());
+
+        //vanity under jcr:content
+        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
+        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
+        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
+
+        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
+        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
+        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
+        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
+        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
+        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
+
+        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
+
+        entries = mapEntries.getResolveMaps();
+        assertEquals(4, entries.size());
+
+        counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(4, counter.longValue());
+
+        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(2, vanityTargets.size());
+
+        assertNull(vanityTargets.get("/vanityPathOnJcrContent/jcr:content"));
+        assertNotNull(vanityTargets.get("/vanityPathOnJcrContent"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_doAddVanity_1() throws Exception {
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(10L);
+
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+        assertEquals(0, entries.size());
+        Field field = MapEntries.class.getDeclaredField("vanityTargets");
+        field.setAccessible(true);
+        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(0, vanityTargets.size());
+
+        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
+        addResource.setAccessible(true);
+
+        Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
+
+        entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+
+        //bad vanity
+        Resource badVanityPath = mock(Resource.class, "badVanityPath");
+        when(resourceResolver.getResource("/badVanityPath")).thenReturn(badVanityPath);
+        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
+        when(badVanityPath.getName()).thenReturn("badVanityPath");
+        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
+
+        addResource.invoke(mapEntries, "/badVanityPath", new AtomicBoolean());
+
+
+        assertEquals(2, entries.size());
+
+        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(1, vanityTargets.size());
+
+        //vanity under jcr:content
+        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
+        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
+        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
+
+        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
+        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
+        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
+        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
+        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
+        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
+
+        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
+
+        entries = mapEntries.getResolveMaps();
+        assertEquals(4, entries.size());
+
+        counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(4, counter.longValue());
+
+        vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(2, vanityTargets.size());
+
+        assertNull(vanityTargets.get("/vanityPathOnJcrContent/jcr:content"));
+        assertNotNull(vanityTargets.get("/vanityPathOnJcrContent"));
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_doUpdateVanity() throws Exception {
+        Field field0 = MapEntries.class.getDeclaredField("resolveMapsMap");
+        field0.setAccessible(true);
+        Map<String, List<MapEntry>> resolveMapsMap = (Map<String, List<MapEntry>>) field0.get(mapEntries);
+        assertEquals(1, resolveMapsMap.size());
+
+        Field field = MapEntries.class.getDeclaredField("vanityTargets");
+        field.setAccessible(true);
+        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(0, vanityTargets.size());
+
+        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
+        addResource.setAccessible(true);
+
+        final Method updateResource = MapEntries.class.getDeclaredMethod("updateResource", String.class, AtomicBoolean.class);
+        updateResource.setAccessible(true);
+
+        Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
+
+        assertEquals(2, resolveMapsMap.size());
+        assertEquals(1, vanityTargets.size());
+        assertNotNull(resolveMapsMap.get("/target/justVanityPath"));
+        assertNull(resolveMapsMap.get("/target/justVanityPathUpdated"));
+        assertEquals(1, vanityTargets.get("/justVanityPath").size());
+        assertEquals("/target/justVanityPath", vanityTargets.get("/justVanityPath").get(0));
+
+        //update vanity path
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPathUpdated"));
+        updateResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
+
+        assertEquals(2, resolveMapsMap.size());
+        assertEquals(1, vanityTargets.size());
+        assertNull(resolveMapsMap.get("/target/justVanityPath"));
+        assertNotNull(resolveMapsMap.get("/target/justVanityPathUpdated"));
+        assertEquals(1, vanityTargets.get("/justVanityPath").size());
+        assertEquals("/target/justVanityPathUpdated", vanityTargets.get("/justVanityPath").get(0));
+
+        //vanity under jcr:content
+        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
+        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
+        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
+        when(vanityPathOnJcrContentParent.getValueMap()).thenReturn(buildValueMap());
+
+        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
+        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
+        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
+        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
+        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
+        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
+
+        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
+
+        assertEquals(3, resolveMapsMap.size());
+        assertEquals(2, vanityTargets.size());
+        assertNotNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
+        assertNull(resolveMapsMap.get("/target/vanityPathOnJcrContentUpdated"));
+        assertEquals(1, vanityTargets.get("/vanityPathOnJcrContent").size());
+        assertEquals("/target/vanityPathOnJcrContent", vanityTargets.get("/vanityPathOnJcrContent").get(0));
+
+        //update vanity path
+        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContentUpdated"));
+        updateResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
+
+        assertEquals(3, resolveMapsMap.size());
+        assertEquals(2, vanityTargets.size());
+        assertNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
+        assertNotNull(resolveMapsMap.get("/target/vanityPathOnJcrContentUpdated"));
+        assertEquals(1, vanityTargets.get("/vanityPathOnJcrContent").size());
+        assertEquals("/target/vanityPathOnJcrContentUpdated", vanityTargets.get("/vanityPathOnJcrContent").get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_doRemoveVanity() throws Exception {
+        Field field0 = MapEntries.class.getDeclaredField("resolveMapsMap");
+        field0.setAccessible(true);
+        Map<String, List<MapEntry>> resolveMapsMap = (Map<String, List<MapEntry>>) field0.get(mapEntries);
+        assertEquals(1, resolveMapsMap.size());
+
+        Field field = MapEntries.class.getDeclaredField("vanityTargets");
+        field.setAccessible(true);
+        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(0, vanityTargets.size());
+
+        final Method addResource = MapEntries.class.getDeclaredMethod("addResource", String.class, AtomicBoolean.class);
+        addResource.setAccessible(true);
+
+        Method method1 = MapEntries.class.getDeclaredMethod("doRemoveVanity", String.class);
+        method1.setAccessible(true);
+
+        Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        addResource.invoke(mapEntries, "/justVanityPath", new AtomicBoolean());
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+        assertEquals(2, resolveMapsMap.size());
+        assertEquals(1, vanityTargets.size());
+        assertNotNull(resolveMapsMap.get("/target/justVanityPath"));
+        assertEquals(1, vanityTargets.get("/justVanityPath").size());
+        assertEquals("/target/justVanityPath", vanityTargets.get("/justVanityPath").get(0));
+
+        //remove vanity path
+        method1.invoke(mapEntries, "/justVanityPath");
+
+        counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(0, counter.longValue());
+
+        assertEquals(1, resolveMapsMap.size());
+        assertEquals(0, vanityTargets.size());
+        assertNull(resolveMapsMap.get("/target/justVanityPath"));
+
+        //vanity under jcr:content
+        Resource vanityPathOnJcrContentParent = mock(Resource.class, "vanityPathOnJcrContentParent");
+        when(vanityPathOnJcrContentParent.getPath()).thenReturn("/vanityPathOnJcrContent");
+        when(vanityPathOnJcrContentParent.getName()).thenReturn("vanityPathOnJcrContent");
+
+        Resource vanityPathOnJcrContent = mock(Resource.class, "vanityPathOnJcrContent");
+        when(resourceResolver.getResource("/vanityPathOnJcrContent/jcr:content")).thenReturn(vanityPathOnJcrContent);
+        when(vanityPathOnJcrContent.getPath()).thenReturn("/vanityPathOnJcrContent/jcr:content");
+        when(vanityPathOnJcrContent.getName()).thenReturn("jcr:content");
+        when(vanityPathOnJcrContent.getParent()).thenReturn(vanityPathOnJcrContentParent);
+        when(vanityPathOnJcrContent.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/vanityPathOnJcrContent"));
+
+        addResource.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content", new AtomicBoolean());
+
+        assertEquals(2, resolveMapsMap.size());
+        assertEquals(1, vanityTargets.size());
+        assertNotNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
+        assertEquals(1,vanityTargets.get("/vanityPathOnJcrContent").size());
+        assertEquals("/target/vanityPathOnJcrContent", vanityTargets.get("/vanityPathOnJcrContent").get(0));
+
+        //remove vanity path
+        method1.invoke(mapEntries, "/vanityPathOnJcrContent/jcr:content");
+
+        assertEquals(1, resolveMapsMap.size());
+        assertEquals(0, vanityTargets.size());
+        assertNull(resolveMapsMap.get("/target/vanityPathOnJcrContent"));
+
+    }
+/*
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_doUpdateVanityOrder() throws Exception {
+        Field field0 = MapEntries.class.getDeclaredField("resolveMapsMap");
+        field0.setAccessible(true);
+        Map<String, List<MapEntry>> resolveMapsMap = (Map<String, List<MapEntry>>) field0.get(mapEntries);
+        assertEquals(1, resolveMapsMap.size());
+
+        Field field = MapEntries.class.getDeclaredField("vanityTargets");
+        field.setAccessible(true);
+        Map<String, List<String>> vanityTargets = (Map<String, List<String>>) field.get(mapEntries);
+        assertEquals(0, vanityTargets.size());
+
+        Method method = MapEntries.class.getDeclaredMethod("doAddVanity", String.class);
+        method.setAccessible(true);
+
+        Method method1 = MapEntries.class.getDeclaredMethod("doUpdateVanityOrder", String.class, boolean.class);
+        method1.setAccessible(true);
+
+        Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        method.invoke(mapEntries, "/justVanityPath");
+
+        Resource justVanityPath2 = mock(Resource.class, "justVanityPath2");
+        when(resourceResolver.getResource("/justVanityPath2")).thenReturn(justVanityPath2);
+        when(justVanityPath2.getPath()).thenReturn("/justVanityPath2");
+        when(justVanityPath2.getName()).thenReturn("justVanityPath2");
+        when(justVanityPath2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 100));
+
+        method.invoke(mapEntries, "/justVanityPath2");
+
+        assertEquals(2, resolveMapsMap.size());
+        assertEquals(2, vanityTargets.size());
+        assertNotNull(resolveMapsMap.get("/target/justVanityPath"));
+
+        Iterator <MapEntry> iterator = resolveMapsMap.get("/target/justVanityPath").iterator();
+        assertEquals("/justVanityPath2$1", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath$1", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath2.html", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath.html", iterator.next().getRedirect()[0]);
+        assertFalse(iterator.hasNext());
+
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 1000));
+        method1.invoke(mapEntries, "/justVanityPath",false);
+
+        iterator = resolveMapsMap.get("/target/justVanityPath").iterator();
+        assertEquals("/justVanityPath$1", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath2$1", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath.html", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath2.html", iterator.next().getRedirect()[0]);
+        assertFalse(iterator.hasNext());
+
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+        method1.invoke(mapEntries, "/justVanityPath",true);
+
+        iterator = resolveMapsMap.get("/target/justVanityPath").iterator();
+        assertEquals("/justVanityPath2$1", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath$1", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath2.html", iterator.next().getRedirect()[0]);
+        assertEquals("/justVanityPath.html", iterator.next().getRedirect()[0]);
+        assertFalse(iterator.hasNext());
+    }
+*/
+
+    @Test
+    public void test_isValidVanityPath() throws Exception {
+        Method method = MapEntries.class.getDeclaredMethod("isValidVanityPath", String.class);
+        method.setAccessible(true);
+
+        assertFalse((Boolean)method.invoke(mapEntries, "/jcr:system/node"));
+
+        assertTrue((Boolean)method.invoke(mapEntries, "/justVanityPath"));
+    }
+
+    @Test
+    //SLING-4891
+    public void test_getVanityPaths_1() throws Exception {
+
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
+
+        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, "/notExisting");
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(0, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_getVanityPaths_2() throws Exception {
+
+        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
+
+        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+
+        final Resource justVanityPath2 = mock(Resource.class, "justVanityPath2");
+        when(resourceResolver.getResource("/justVanityPath2")).thenReturn(justVanityPath2);
+        when(justVanityPath2.getPath()).thenReturn("/justVanityPath2");
+        when(justVanityPath2.getName()).thenReturn("justVanityPath2");
+        when(justVanityPath2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 100));
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(4, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_getVanityPaths_3() throws Exception {
+
+        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
+        when(this.resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(false);
+
+        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(0, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_getVanityPaths_4() throws Exception {
+
+        final Resource badVanityPath = mock(Resource.class, "badVanityPath");
+        when(badVanityPath.getPath()).thenReturn("/badVanityPath");
+        when(badVanityPath.getName()).thenReturn("badVanityPath");
+        when(badVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/content/mypage/en-us-{132"));
+
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(badVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(0L);
+        when(this.resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(true);
+
+        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, "/content/mypage/en-us-{132");
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(0, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_getVanityPaths_5() throws Exception {
+
+        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(2L);
+        when(this.resourceResolverFactory.isMaxCachedVanityPathEntriesStartup()).thenReturn(false);
+
+        Method method = MapEntries.class.getDeclaredMethod("getVanityPaths", String.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+
+        final Resource justVanityPath2 = mock(Resource.class, "justVanityPath2");
+        when(resourceResolver.getResource("/justVanityPath2")).thenReturn(justVanityPath2);
+        when(justVanityPath2.getPath()).thenReturn("/justVanityPath2");
+        when(justVanityPath2.getName()).thenReturn("justVanityPath2");
+        when(justVanityPath2.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath","sling:vanityOrder", 100));
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_loadVanityPaths() throws Exception {
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(2L);
+
+        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        Method method = MapEntries.class.getDeclaredMethod("loadVanityPaths", ResourceResolver.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, resourceResolver);
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_loadVanityPaths_1() throws Exception {
+
+        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+        Method method = MapEntries.class.getDeclaredMethod("loadVanityPaths", ResourceResolver.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, resourceResolver);
+
+        Field vanityCounter = MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+    }
+
+    @Test
+    //SLING-4891
+    public void test_getMapEntryList() throws Exception {
+
+        List<MapEntry> entries = mapEntries.getResolveMaps();
+        assertEquals(0, entries.size());
+
+
+        final Resource justVanityPath = mock(Resource.class,
+                "justVanityPath");
+
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath",
+                "/target/justVanityPath"));
+
+        when(resourceResolver.findResources(anyString(),
+                eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+                    if
+                    (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                        return Collections.singleton(justVanityPath).iterator();
+                    } else {
+                        return Collections.emptyIterator();
+                    }
+                });
+
+        Method method =
+                MapEntries.class.getDeclaredMethod("getMapEntryList",String.class);
+        method.setAccessible(true);
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+
+        Field vanityCounter =
+                MapEntries.class.getDeclaredField("vanityCounter");
+        vanityCounter.setAccessible(true);
+        AtomicLong counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+
+        method.invoke(mapEntries, "/target/justVanityPath");
+
+        entries = mapEntries.getResolveMaps();
+        assertEquals(2, entries.size());
+
+        counter = (AtomicLong) vanityCounter.get(mapEntries);
+        assertEquals(2, counter.longValue());
+    }
+
+    @Test
+    //SLING-4883
+    public void test_concurrent_getResolveMapsIterator() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(10);
+
+        final Resource justVanityPath = mock(Resource.class, "justVanityPath");
+        when(resourceResolver.getResource("/justVanityPath")).thenReturn(justVanityPath);
+        when(justVanityPath.getPath()).thenReturn("/justVanityPath");
+        when(justVanityPath.getName()).thenReturn("justVanityPath");
+        when(justVanityPath.getValueMap()).thenReturn(buildValueMap("sling:vanityPath", "/target/justVanityPath"));
+
+
+        when(resourceResolver.findResources(anyString(), eq("JCR-SQL2"))).thenAnswer((Answer<Iterator<Resource>>) invocation -> {
+            if (invocation.getArguments()[0].toString().contains("sling:vanityPath")) {
+                return Collections.singleton(justVanityPath).iterator();
+            } else {
+                return Collections.emptyIterator();
+            }
+        });
+
+
+        when(this.resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(2L);
+
+        ArrayList<DataFuture> list = new ArrayList<>();
+        for (int i =0;i<10;i++) {
+            list.add(createDataFuture(pool, mapEntries));
+        }
+
+       for (DataFuture df : list) {
+           df.future.get();
+        }
+
+    }
+
+    @Test
+    public void test_vanitypath_disabled() throws Exception {
+        // initialize with having vanity path disabled - must not throw errors here or on disposal
+        when(resourceResolverFactory.isVanityPathEnabled()).thenReturn(false);
+
+        mapEntries = new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
+
+        mapEntries.doInit();
+    }
+
+    // utilities for testing vanity path queries
+
+    private static String VPQSTART = "SELECT [sling:vanityPath], [sling:redirect], [sling:redirectStatus] FROM [nt:base] WHERE NOT isdescendantnode('/jcr:system') AND [sling:vanityPath] IS NOT NULL AND FIRST([sling:vanityPath]) >= '";
+    private static String VPQEND = "' ORDER BY FIRST([sling:vanityPath])";
+
+    private boolean matchesPagedQuery(String query) {
+        return query.startsWith(VPQSTART) && query.endsWith(VPQEND);
+    }
+
+    private String extractStartPath(String query) {
+        String remainder = query.substring(VPQSTART.length());
+        return remainder.substring(0, remainder.length() - VPQEND.length());
+    }
+
+    private String getFirstVanityPath(Resource r) {
+        String[] vp = r.getValueMap().get("sling:vanityPath", new String[0]);
+        return vp.length == 0 ? "": vp[0];
+    }
+
+    private Comparator<Resource> vanityResourceComparator = (o1, o2) -> {
+        String s1 = getFirstVanityPath(o1);
+        String s2 = getFirstVanityPath(o2);
+        return s1.compareTo(s2);
+    };
+}

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathMapEntriesTest.java
@@ -129,7 +129,6 @@ public class VanityPathMapEntriesTest extends AbstractMappingMapEntriesTest {
         when(resourceResolverFactory.getServiceResourceResolver(any(Map.class))).thenReturn(resourceResolver);
         when(resourceResolverFactory.isVanityPathEnabled()).thenReturn(true);
         when(resourceResolverFactory.getVanityPathConfig()).thenReturn(configs);
-        when(resourceResolverFactory.isOptimizeAliasResolutionEnabled()).thenReturn(true);
         when(resourceResolverFactory.getObservationPaths()).thenReturn(new Path[] {new Path("/")});
         when(resourceResolverFactory.getMapRoot()).thenReturn(MapEntries.DEFAULT_MAP_ROOT);
         when(resourceResolverFactory.getMaxCachedVanityPathEntries()).thenReturn(-1L);


### PR DESCRIPTION
1. in MapEntries: move most vanity path related code into a single place for later refactoring
2. Move vanity path related tests into separate test class
3. Code cleanup in test cases

Note that line coverage warning is due to code being moved around in MapEntries. Test coverage for vanity paths will be improved when factored out into a separate class.