### PR TITLE
SLING-12651: avoid re-assignment of resolveMapsMap

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -126,7 +126,7 @@ public class MapEntries implements
 
     private volatile ServiceRegistration<ResourceChangeListener> registration;
 
-    private Map<String, List<MapEntry>> resolveMapsMap;
+    private final Map<String, List<MapEntry>> resolveMapsMap;
 
     // Temporary cache for use while doing async vanity path query
     private Map<String, List<MapEntry>> temporaryResolveMapsMap;
@@ -176,7 +176,7 @@ public class MapEntries implements
         this.factory = factory;
         this.eventAdmin = eventAdmin;
 
-        this.resolveMapsMap = Collections.singletonMap(GLOBAL_LIST_KEY, Collections.emptyList());
+        this.resolveMapsMap = new ConcurrentHashMap<>(Map.of(GLOBAL_LIST_KEY, List.of()));
         this.mapMaps = Collections.<MapEntry> emptyList();
         this.vanityTargets = Collections.<String,List <String>>emptyMap();
         this.aliasMapsMap = new ConcurrentHashMap<>();
@@ -274,8 +274,6 @@ public class MapEntries implements
                     isOptimizeAliasResolutionEnabled = false;
                 }
             }
-
-            this.resolveMapsMap = new ConcurrentHashMap<>();
 
             doUpdateConfiguration();
 


### PR DESCRIPTION
Currently, resolveMapsMap is initialized as immutable singleton map containing a mapping of GLOBAL_LIST_KEY to an empty list.

Later on, during alias init, it is changed to a ConcurrentHashMap and it then immediately gets populated with a mapping for that key. For [SLING-9782](https://issues.apache.org/jira/browse/SLING-9782) this was changed to init the Map even if the ("optimized") alias init fails.

Rather than that, let's always init the map as writeable map, which also allows to make it final (which will help with future refactorings).