### PR TITLE
SLING-12666: VanityPathHandler, address warnings, refactor

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -375,7 +375,7 @@ public class VanityPathHandler {
      * @param path The resource path to check
      * @return {@code true} if this is valid, {@code false} otherwise
      */
-    boolean isValidVanityPath(final String path){
+    boolean isValidVanityPath(final String path) {
         if (path == null) {
             throw new IllegalArgumentException("Unexpected null path");
         }
@@ -387,15 +387,15 @@ public class VanityPathHandler {
         }
 
         // check allow/deny list
-        if ( this.factory.getVanityPathConfig() != null ) {
+        if (this.factory.getVanityPathConfig() != null) {
             boolean allowed = false;
             for(final MapConfigurationProvider.VanityPathConfig config : this.factory.getVanityPathConfig()) {
-                if ( path.startsWith(config.prefix) ) {
+                if (path.startsWith(config.prefix)) {
                     allowed = !config.isExclude;
                     break;
                 }
             }
-            if ( !allowed ) {
+            if (!allowed) {
                 log.debug("isValidVanityPath: not valid as not in allow list {}", path);
                 return false;
             }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -418,10 +418,10 @@ public class VanityPathHandler {
             it = new PagedQueryIterator("vanity path", PROP_VANITY_PATH, resolver, queryStringWithSort, 2000);
         } catch (QuerySyntaxException ex) {
             log.debug("sort with first() not supported, falling back to base query", ex);
-            it = queryUnpaged("vanity path", baseQueryString, resolver);
+            it = queryUnpaged(baseQueryString, resolver);
         } catch (UnsupportedOperationException ex) {
             log.debug("query failed as unsupported, retrying without paging/sorting", ex);
-            it = queryUnpaged("vanity path", baseQueryString, resolver);
+            it = queryUnpaged(baseQueryString, resolver);
         }
 
         long count = 0;
@@ -668,12 +668,12 @@ public class VanityPathHandler {
         }
     }
 
-    private Iterator<Resource> queryUnpaged(String subject, String query, ResourceResolver resolver) {
-        log.debug("start {} query: {}", subject, query);
+    private Iterator<Resource> queryUnpaged(String query, ResourceResolver resolver) {
+        log.debug("start vanity path query: {}", query);
         long queryStart = System.nanoTime();
         final Iterator<Resource> it = resolver.findResources(query, "JCR-SQL2");
         long queryElapsed = System.nanoTime() - queryStart;
-        log.debug("end {} query; elapsed {}ms", subject, TimeUnit.NANOSECONDS.toMillis(queryElapsed));
+        log.debug("end vanity path query; elapsed {}ms", TimeUnit.NANOSECONDS.toMillis(queryElapsed));
         return it;
     }
 }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -372,12 +372,12 @@ public class VanityPathHandler {
                 final Resource resource = i.next();
                 boolean isValid = false;
                 for(final Path sPath : this.factory.getObservationPaths()) {
-                    if ( sPath.matches(resource.getPath())) {
+                    if (sPath.matches(resource.getPath())) {
                         isValid = true;
                         break;
                     }
                 }
-                if ( isValid ) {
+                if (isValid) {
                     totalValid += 1;
                     if (this.vanityPathsProcessed.get()
                             && (this.factory.isMaxCachedVanityPathEntriesStartup()

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -559,6 +559,7 @@ public class VanityPathHandler {
                         entry1 = createMapEntry(url + "$", httpStatus, vanityOrder, redirect);
 
                         // 2. entry with extension
+                        // ("\\." matches a single dot)
                         entry2 = createMapEntry(url + "\\." + extension, httpStatus, vanityOrder, redirect);
                     } else {
                         // name without extension
@@ -567,6 +568,7 @@ public class VanityPathHandler {
                         entry1 = createMapEntry(url + "$", httpStatus, vanityOrder, redirect + ".html");
 
                         // 2. entry with match supporting selectors and extension
+                        // ("(\\..*)" matches a single dot followed by any characters)
                         entry2 = createMapEntry(url + "(\\..*)", httpStatus, vanityOrder, redirect + "$1");
 
                     }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -510,7 +510,7 @@ public class VanityPathHandler {
                 // whether the target is attained by an external redirect or
                 // by an internal redirect is defined by the sling:redirect
                 // property
-                final int status = props.get(PROP_REDIRECT_EXTERNAL, false) ? props.get(
+                final int httpStatus = props.get(PROP_REDIRECT_EXTERNAL, false) ? props.get(
                         PROP_REDIRECT_EXTERNAL_REDIRECT_STATUS, factory.getDefaultVanityPathRedirectStatus())
                         : -1;
 
@@ -520,19 +520,19 @@ public class VanityPathHandler {
                 if (addToCache) {
                     if (redirectName.indexOf('.') > -1) {
                         // 1. entry with exact match
-                        this.addEntry(entryMap, checkPath, getMapEntry(url + "$", status, vanityOrder, redirect));
+                        this.addEntry(entryMap, checkPath, createMapEntry(url + "$", httpStatus, vanityOrder, redirect));
 
                         final int idx = redirectName.lastIndexOf('.');
                         final String extension = redirectName.substring(idx + 1);
 
                         // 2. entry with extension
-                        addedEntry = this.addEntry(entryMap, checkPath, getMapEntry(url + "\\." + extension, status, vanityOrder, redirect));
+                        addedEntry = this.addEntry(entryMap, checkPath, createMapEntry(url + "\\." + extension, httpStatus, vanityOrder, redirect));
                     } else {
                         // 1. entry with exact match
-                        this.addEntry(entryMap, checkPath, getMapEntry(url + "$", status, vanityOrder, redirect + ".html"));
+                        this.addEntry(entryMap, checkPath, createMapEntry(url + "$", httpStatus, vanityOrder, redirect + ".html"));
 
                         // 2. entry with match supporting selectors and extension
-                        addedEntry = this.addEntry(entryMap, checkPath, getMapEntry(url + "(\\..*)", status, vanityOrder, redirect + "$1"));
+                        addedEntry = this.addEntry(entryMap, checkPath, createMapEntry(url + "(\\..*)", httpStatus, vanityOrder, redirect + "$1"));
                     }
                     if (addedEntry) {
                         // 3. keep the path to return
@@ -657,13 +657,13 @@ public class VanityPathHandler {
         return checkPath;
     }
 
-    private MapEntry getMapEntry(final String url, final int status, long order,
-                                 final String... redirect) {
+    private MapEntry createMapEntry(final String urlPattern, final int httpStatus, long order,
+                                    final String... redirects) {
         try {
-            return new MapEntry(url, status, false, order, redirect);
+            return new MapEntry(urlPattern, httpStatus, false, order, redirects);
         } catch (IllegalArgumentException iae) {
             // ignore this entry
-            log.debug("ignored entry for {} due to exception", url, iae);
+            log.debug("ignored entry for {} due to exception", urlPattern, iae);
             return null;
         }
     }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -630,23 +630,23 @@ public class VanityPathHandler {
             return false;
         } else {
             List<MapEntry> entries = entryMap.get(key);
-            if (entries == null) {
-                entries = new ArrayList<>();
-                entries.add(entry);
-                entryMap.put(key, entries);
-            } else {
-                List<MapEntry> entriesCopy = new ArrayList<>(entries);
-                entriesCopy.add(entry);
-                // and finally sort list
-                Collections.sort(entriesCopy);
-                entryMap.put(key, entriesCopy);
-                int size = entriesCopy.size();
-                if (size == 10) {
-                    log.debug(">= 10 MapEntries for {} - check your configuration", key);
-                } else if (size == 100) {
-                    log.info(">= 100 MapEntries for {} - check your configuration", key);
-                }
+
+            // copy existing list contents (when not empty), add new entry, then sort
+            List<MapEntry> entriesCopy = new ArrayList<>(entries != null ? entries : List.of());
+            entriesCopy.add(entry);
+            Collections.sort(entriesCopy);
+
+            // update map with new list
+            entryMap.put(key, entriesCopy);
+
+            // warn when list of entries for one key grows
+            int size = entriesCopy.size();
+            if (size == 10) {
+                log.debug(">= 10 MapEntries for {} - check your configuration", key);
+            } else if (size == 100) {
+                log.info(">= 100 MapEntries for {} - check your configuration", key);
             }
+
             return true;
         }
     }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -647,14 +647,13 @@ public class VanityPathHandler {
             return true;
         }
     }
-    private String getActualContentPath(final String path){
-        final String checkPath;
-        if ( path.endsWith(JCR_CONTENT_SUFFIX) ) {
-            checkPath = ResourceUtil.getParent(path);
+
+    private String getActualContentPath(final String path) {
+        if (path.endsWith(JCR_CONTENT_SUFFIX)) {
+            return ResourceUtil.getParent(path);
         } else {
-            checkPath = path;
+            return path;
         }
-        return checkPath;
     }
 
     private MapEntry createMapEntry(final String urlPattern, final int httpStatus, long order,

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -519,30 +519,46 @@ public class VanityPathHandler {
 
                 final String checkPath = result[1];
 
-                boolean addedEntry;
                 if (addToCache) {
-                    if (redirectName.indexOf('.') > -1) {
-                        // 1. entry with exact match
-                        this.addEntry(entryMap, checkPath, createMapEntry(url + "$", httpStatus, vanityOrder, redirect));
+                    MapEntry entry1;
+                    MapEntry entry2;
 
-                        final int idx = redirectName.lastIndexOf('.');
-                        final String extension = redirectName.substring(idx + 1);
+                    if (redirectName.contains(".")) {
+                        // name with extension
+                        String extension = redirectName.substring(redirectName.lastIndexOf('.') + 1);
+
+                        // 1. entry with exact match
+                        entry1 = createMapEntry(url + "$", httpStatus, vanityOrder, redirect);
 
                         // 2. entry with extension
-                        addedEntry = this.addEntry(entryMap, checkPath, createMapEntry(url + "\\." + extension, httpStatus, vanityOrder, redirect));
+                        entry2 = createMapEntry(url + "\\." + extension, httpStatus, vanityOrder, redirect);
                     } else {
+                        // name without extension
+
                         // 1. entry with exact match
-                        this.addEntry(entryMap, checkPath, createMapEntry(url + "$", httpStatus, vanityOrder, redirect + ".html"));
+                        entry1 = createMapEntry(url + "$", httpStatus, vanityOrder, redirect + ".html");
 
                         // 2. entry with match supporting selectors and extension
-                        addedEntry = this.addEntry(entryMap, checkPath, createMapEntry(url + "(\\..*)", httpStatus, vanityOrder, redirect + "$1"));
+                        entry2 = createMapEntry(url + "(\\..*)", httpStatus, vanityOrder, redirect + "$1");
+
                     }
-                    if (addedEntry) {
-                        // 3. keep the path to return
+
+                    int count = 0;
+
+                    if (this.addEntry(entryMap, checkPath, entry1)) {
+                        count += 1;
+                    }
+
+                    if (this.addEntry(entryMap, checkPath, entry2)) {
+                        count += 1;
+                    }
+
+                    if (count > 0) {
+                        // keep the path to return
                         this.updateTargetPaths(targetPaths, redirect, checkPath);
 
                         if (updateCounter) {
-                            vanityCounter.addAndGet(2);
+                            vanityCounter.addAndGet(count);
                         }
 
                         // update bloom filter

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -686,9 +686,9 @@ public class VanityPathHandler {
             // warn when list of entries for one key grows
             int size = entriesCopy.size();
             if (size == 10) {
-                log.debug(">= 10 MapEntries for {} - check your configuration", key);
+                log.debug("10 MapEntries for {} - check your configuration", key);
             } else if (size == 100) {
-                log.info(">= 100 MapEntries for {} - check your configuration", key);
+                log.info("100 MapEntries for {} - check your configuration", key);
             }
 
             return true;

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -159,8 +159,8 @@ public class VanityPathHandler {
             try {
                 temporaryResolveMapsMap = Collections.synchronizedMap(new LRUMap<>(SIZELIMIT));
                 execute();
-            } catch (Throwable t) {
-                log.error("vanity path initializer thread terminated with a throwable", t);
+            } catch (Exception ex) {
+                log.error("vanity path initializer thread terminated with an exception", ex);
             }
         }
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/VanityPathHandler.java
@@ -389,7 +389,8 @@ public class VanityPathHandler {
         // check allow/deny list
         if (this.factory.getVanityPathConfig() != null) {
             boolean allowed = false;
-            for(final MapConfigurationProvider.VanityPathConfig config : this.factory.getVanityPathConfig()) {
+            for (MapConfigurationProvider.VanityPathConfig config : this.factory.getVanityPathConfig()) {
+                // process the first config entry matching the path
                 if (path.startsWith(config.prefix)) {
                     allowed = !config.isExclude;
                     break;
@@ -400,6 +401,8 @@ public class VanityPathHandler {
                 return false;
             }
         }
+
+        // either no allow/deny list, or no config entry found
         return true;
     }
 


### PR DESCRIPTION
1. Renames variables/parameters for clarity
2. fixes whitespace
3. simplifies code
4. extract sub methods when nested too deeply
5. removes the magic number "2" when counting cached map entries for vanity paths
6. other minor Sonar complaints