### PR TITLE
SLING-12741 - NPE resource resolver during resource provider unregisteration

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/providers/ResourceProviderTracker.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/providers/ResourceProviderTracker.java
@@ -304,7 +304,7 @@ public class ResourceProviderTracker implements ResourceProviderStorageProvider 
 
         // update change listener (only once)
         final ChangeListener cl = this.listener;
-        if (cl != null) {
+        if (cl != null && deactivateHandler != null) {
             cl.providerRemoved(info.getAuthType() != AuthType.no, deactivateHandler.isUsed());
         }
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/providers/ResourceProviderTrackerTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/providers/ResourceProviderTrackerTest.java
@@ -37,7 +37,6 @@ import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.event.EventAdmin;
 
 import static org.junit.Assert.assertEquals;
@@ -253,7 +252,7 @@ public class ResourceProviderTrackerTest {
     }
 
     @Test
-    public void testRemoveSamePathResourceProvider() throws InvalidSyntaxException {
+    public void testRemoveSamePathResourceProvider() throws Exception {
         try {
             final ResourceProviderTracker tracker = new ResourceProviderTracker();
             tracker.setObservationReporterGenerator(

--- a/src/test/java/org/apache/sling/resourceresolver/impl/providers/ResourceProviderTrackerTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/providers/ResourceProviderTrackerTest.java
@@ -37,11 +37,13 @@ import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.event.EventAdmin;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 public class ResourceProviderTrackerTest {
@@ -248,6 +250,49 @@ public class ResourceProviderTrackerTest {
 
         assertEquals(2, dto.providers.length);
         assertEquals(1, dto.failedProviders.length);
+    }
+
+    @Test
+    public void testRemoveSamePathResourceProvider() throws InvalidSyntaxException {
+        try {
+            final ResourceProviderTracker tracker = new ResourceProviderTracker();
+            tracker.setObservationReporterGenerator(
+                    new SimpleObservationReporterGenerator(new NoDothingObservationReporter()));
+
+            final AtomicBoolean removedCalled = new AtomicBoolean(false);
+            final ChangeListener listener = new ChangeListener() {
+
+                @Override
+                public void providerAdded() {}
+
+                @Override
+                public void providerRemoved(boolean stateful, boolean used) {
+                    removedCalled.set(true);
+                }
+            };
+            tracker.activate(context.bundleContext(), eventAdmin, listener);
+
+            @SuppressWarnings("unchecked")
+            ResourceProvider<Object> rp1 = mock(ResourceProvider.class);
+            final ResourceProviderInfo info1 = fixture.registerResourceProvider(rp1, "/temp/path", AuthType.no, 101);
+
+            @SuppressWarnings("unchecked")
+            ResourceProvider<Object> rp2 = mock(ResourceProvider.class);
+            final ResourceProviderInfo info2 = fixture.registerResourceProvider(rp2, "/temp/path", AuthType.no, 100);
+
+            // check removed is not called yet
+            assertFalse(removedCalled.get());
+            // unregister the provider with lower service rank
+            fixture.unregisterResourceProvider(info2);
+
+            // removed should not be called after unregistering the provider with lower service rank
+            assertFalse(removedCalled.get());
+
+            fixture.unregisterResourceProvider(info1);
+            assertTrue(removedCalled.get());
+        } catch (NullPointerException e) {
+            fail("NullPointerException should not be thrown: " + e.getMessage());
+        }
     }
 
     static final class NoDothingObservationReporter implements ObservationReporter {


### PR DESCRIPTION
This PR fixes following exception observed during unregistration of resource provider:

```
[FelixLogListener] Events.Framework.org.apache.sling.resourceresolver FrameworkEvent ERROR (java.lang.NullPointerException: Cannot invoke "org.apache.sling.resourceresolver.impl.providers.ResourceProviderHandler.isUsed()" because "deactivateHandler" is null)
java.lang.NullPointerException: Cannot invoke "org.apache.sling.resourceresolver.impl.providers.ResourceProviderHandler.isUsed()" because "deactivateHandler" is null
	at org.apache.sling.resourceresolver.impl.providers.ResourceProviderTracker.remove(ResourceProviderTracker.java:301) 
	at org.apache.sling.resourceresolver.impl.providers.ResourceProviderTracker.unregister(ResourceProviderTracker.java:202) 
	at org.apache.sling.resourceresolver.impl.providers.ResourceProviderTracker$1.removedService(ResourceProviderTracker.java:111) 
	at org.apache.sling.resourceresolver.impl.providers.ResourceProviderTracker$1.removedService(ResourceProviderTracker.java:107) 
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:970)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:872)
	at org.osgi.util.tracker.AbstractTracked.untrack(AbstractTracked.java:341)
	at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:912)
	at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990)
	at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838)
	at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545)
	at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4863)
	at org.apache.felix.framework.Felix.access$000(Felix.java:111)
	at org.apache.felix.framework.Felix$1.serviceChanged(Felix.java:440)
```