### PR TITLE
SLING-12763: cleanup API of AliasHandler wrt 'optimized resolution'

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -70,7 +70,8 @@ class AliasHandler {
      * The key of the map is the parent path, while the value is a map with the
      * resource name as key and the actual aliases as values
      */
-    @NotNull Map<String, Map<String, Collection<String>>> aliasMapsMap;
+    @NotNull
+    Map<String, Map<String, Collection<String>>> aliasMapsMap;
 
     boolean mapIsInitialized = false;
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -70,7 +70,7 @@ class AliasHandler {
      * The key of the map is the parent path, while the value is a map with the
      * resource name as key and the actual aliases as values
      */
-    Map<String, Map<String, Collection<String>>> aliasMapsMap;
+    @NotNull Map<String, Map<String, Collection<String>>> aliasMapsMap;
 
     boolean mapIsInitialized = false;
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -1178,7 +1178,6 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
         AliasHandler ah = mapEntries.ah;
         mapEntries.dispose();
         ah.initializeAliases();
-        boolean enabled = ah.usesCache();
-        assertFalse("alias handler should not have set up cache", enabled);
+        assertFalse("alias handler should not have set up cache", ah.usesCache());
     }
 }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -201,7 +201,8 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
     @Test
     public void internal_test_simple_alias_support_throwing_unsupported_operation_exception_exception() {
         prepareMapEntriesForAlias(false, false, UnsupportedOperationException.class, "foo", "bar");
-        assertFalse(mapEntries.ah.initializeAliases());
+        mapEntries.ah.initializeAliases();
+        assertFalse(mapEntries.ah.usesCache());
     }
 
     @Test
@@ -1176,7 +1177,8 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
     public void test_initAliasesAfterDispose() {
         AliasHandler ah = mapEntries.ah;
         mapEntries.dispose();
-        boolean enabled = ah.initializeAliases();
-        assertFalse("return value (isOptimizeAliasResolutionEnabled) should be false", enabled);
+        ah.initializeAliases();
+        boolean enabled = ah.usesCache();
+        assertFalse("alias handler should not have set up cache", enabled);
     }
 }


### PR DESCRIPTION
- `AliasHandler.initializeAliases()` returns void now, as the return value was misleading anyway. It has been replaced by `AliasHandler.usesCache()`, indicating the Maps have been initialized.
- Make sure that the `AliasHandler.aliasMapsMap` is always non-null.

This also aligns Alias init with VP init.