### PR TITLE
SLING-12777: alias refactoring - make ResourceMapperImpl ignorant of optimimized/non-optimized case

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -343,7 +343,7 @@ class AliasHandler {
                 Resource parent = resolver.getResource(parentPath);
                 return getAliasMapFromRepo(parent);
             } catch (LoginException ex) {
-                log.error("Could not obtain resolver", ex);
+                log.error("Could not obtain resolver to resolve any aliases from repository", ex);
                 return null;
             }
         }

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -88,10 +88,10 @@ class AliasHandler {
     final AtomicLong detectedInvalidAliases;
 
     public AliasHandler(
-            MapConfigurationProvider factory,
-            ReentrantLock initializing,
-            Runnable doUpdateConfiguration,
-            Runnable sendChangeEvent) {
+            @NotNull MapConfigurationProvider factory,
+            @NotNull ReentrantLock initializing,
+            @NotNull Runnable doUpdateConfiguration,
+            @NotNull Runnable sendChangeEvent) {
         this.factory = factory;
         this.initializing = initializing;
         this.doUpdateConfiguration = doUpdateConfiguration;
@@ -148,7 +148,7 @@ class AliasHandler {
                     } else if (!invalidAliases.isEmpty()) {
                         log.warn("There are {} invalid aliases: {}", invalidAliases.size(), invalidAliases);
                     }
-                } catch (final Exception e) {
+                } catch (Exception e) {
                     this.aliasMapsMap = UNITIALIZED_MAP;
                     logDisableAliasOptimization(e);
                 }
@@ -165,7 +165,7 @@ class AliasHandler {
         return this.aliasMapsMap != UNITIALIZED_MAP;
     }
 
-    boolean doAddAlias(final Resource resource) {
+    boolean doAddAlias(@NotNull Resource resource) {
         if (this.aliasMapsMap != UNITIALIZED_MAP) {
             return loadAlias(resource, this.aliasMapsMap, null, null);
         } else {
@@ -181,7 +181,10 @@ class AliasHandler {
      * @return {@code true} if a change happened
      */
     boolean removeAlias(
-            ResourceResolver resolver, final String contentPath, final String path, final Runnable notifyOfChange) {
+            @Nullable ResourceResolver resolver,
+            @NotNull String contentPath,
+            @Nullable String path,
+            @NotNull Runnable notifyOfChange) {
         if (this.aliasMapsMap != UNITIALIZED_MAP) {
             return removeAliasInMap(resolver, contentPath, path, notifyOfChange);
         } else {
@@ -190,9 +193,12 @@ class AliasHandler {
     }
 
     private boolean removeAliasInMap(
-            ResourceResolver resolver, final String contentPath, final String path, final Runnable notifyOfChange) {
+            @Nullable ResourceResolver resolver,
+            @NotNull String contentPath,
+            @Nullable String path,
+            @NotNull Runnable notifyOfChange) {
 
-        final String resourcePath = computeResourcePath(contentPath, path);
+        String resourcePath = computeResourcePath(contentPath, path);
 
         if (resourcePath == null) {
             // early exit
@@ -202,7 +208,7 @@ class AliasHandler {
         this.initializing.lock();
 
         try {
-            final Map<String, Collection<String>> aliasMapEntry = aliasMapsMap.get(contentPath);
+            Map<String, Collection<String>> aliasMapEntry = aliasMapsMap.get(contentPath);
             if (aliasMapEntry != null) {
                 notifyOfChange.run();
                 handleAliasRemoval(resolver, contentPath, resourcePath, aliasMapEntry);
@@ -221,8 +227,8 @@ class AliasHandler {
 
         if (path != null && path.length() > contentPath.length()) {
             // path -> (contentPath + subPath)
-            final String subPath = path.substring(contentPath.length() + 1);
-            final int firstSlash = subPath.indexOf('/');
+            String subPath = path.substring(contentPath.length() + 1);
+            int firstSlash = subPath.indexOf('/');
 
             if (firstSlash == -1) {
                 // no slash in subPath
@@ -259,7 +265,7 @@ class AliasHandler {
             if (containingResource.getValueMap().containsKey(ResourceResolverImpl.PROP_ALIAS)) {
                 doAddAlias(containingResource);
             }
-            final Resource child = containingResource.getChild(JCR_CONTENT);
+            Resource child = containingResource.getChild(JCR_CONTENT);
             if (child != null && child.getValueMap().containsKey(ResourceResolverImpl.PROP_ALIAS)) {
                 doAddAlias(child);
             }
@@ -272,7 +278,7 @@ class AliasHandler {
      * @param resource The resource
      * @return {@code true} if any change
      */
-    boolean doUpdateAlias(final Resource resource) {
+    boolean doUpdateAlias(@NotNull Resource resource) {
         if (this.aliasMapsMap != UNITIALIZED_MAP) {
             return doUpdateAliasInMap(resource);
         } else {
@@ -280,17 +286,16 @@ class AliasHandler {
         }
     }
 
-    private boolean doUpdateAliasInMap(final Resource resource) {
+    private boolean doUpdateAliasInMap(@NotNull Resource resource) {
 
         // resource containing the alias
-        final Resource containingResource = getResourceToBeAliased(resource);
+        Resource containingResource = getResourceToBeAliased(resource);
 
         if (containingResource != null) {
-            final String containingResourceName = containingResource.getName();
-            final String parentPath = ResourceUtil.getParent(containingResource.getPath());
+            String containingResourceName = containingResource.getName();
+            String parentPath = ResourceUtil.getParent(containingResource.getPath());
 
-            final Map<String, Collection<String>> aliasMapEntry =
-                    parentPath == null ? null : aliasMapsMap.get(parentPath);
+            Map<String, Collection<String>> aliasMapEntry = parentPath == null ? null : aliasMapsMap.get(parentPath);
             if (aliasMapEntry != null) {
                 aliasMapEntry.remove(containingResourceName);
                 if (aliasMapEntry.isEmpty()) {
@@ -303,7 +308,7 @@ class AliasHandler {
             if (containingResource.getValueMap().containsKey(ResourceResolverImpl.PROP_ALIAS)) {
                 changed |= doAddAlias(containingResource);
             }
-            final Resource child = containingResource.getChild(JCR_CONTENT);
+            Resource child = containingResource.getChild(JCR_CONTENT);
             if (child != null && child.getValueMap().containsKey(ResourceResolverImpl.PROP_ALIAS)) {
                 changed |= doAddAlias(child);
             }
@@ -315,24 +320,24 @@ class AliasHandler {
         }
     }
 
-    public @NotNull Map<String, Collection<String>> getAliasMap(@Nullable final String parentPath) {
+    public @NotNull Map<String, Collection<String>> getAliasMap(@Nullable String parentPath) {
         Map<String, Collection<String>> result = this.aliasMapsMap != UNITIALIZED_MAP
                 ? getAliasMapFromCache(parentPath)
                 : getAliasMapFromRepo(parentPath);
         return result != null ? result : Collections.emptyMap();
     }
 
-    private @Nullable Map<String, Collection<String>> getAliasMapFromCache(@Nullable final String parentPath) {
+    private @Nullable Map<String, Collection<String>> getAliasMapFromCache(@Nullable String parentPath) {
         return aliasMapsMap.get(parentPath);
     }
 
     // TODO: there's an opportunity for optimization when the caller already has a Resource
-    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable final String parentPath) {
+    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable String parentPath) {
 
         if (parentPath == null) {
             return null;
         } else {
-            try (final ResourceResolver resolver =
+            try (ResourceResolver resolver =
                     factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo(SERVICE_USER))) {
 
                 Resource parent = resolver.getResource(parentPath);
@@ -344,7 +349,7 @@ class AliasHandler {
         }
     }
 
-    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable final Resource parent) {
+    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable Resource parent) {
 
         Map<String, Collection<String>> result = null;
 
@@ -364,18 +369,19 @@ class AliasHandler {
      * Load aliases - Search for all nodes (except under /jcr:system) below
      * configured alias locations having the sling:alias property
      */
+    @NotNull
     private Map<String, Map<String, Collection<String>>> loadAliases(
-            List<String> conflictingAliases, List<String> invalidAliases) {
+            @Nullable List<String> conflictingAliases, @Nullable List<String> invalidAliases) {
 
-        final Map<String, Map<String, Collection<String>>> map = new ConcurrentHashMap<>();
+        Map<String, Map<String, Collection<String>>> map = new ConcurrentHashMap<>();
 
-        try (final ResourceResolver resolver =
+        try (ResourceResolver resolver =
                 factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo(SERVICE_USER))) {
-            final String baseQueryString = generateAliasQuery();
+            String baseQueryString = generateAliasQuery();
 
             Iterator<Resource> it;
             try {
-                final String queryStringWithSort =
+                String queryStringWithSort =
                         baseQueryString + " AND FIRST([sling:alias]) >= '%s' ORDER BY FIRST([sling:alias])";
                 it = new PagedQueryIterator("alias", "sling:alias", resolver, queryStringWithSort, 2000);
             } catch (QuerySyntaxException ex) {
@@ -425,8 +431,9 @@ class AliasHandler {
     /*
      * generate alias query based on configured alias locations
      */
+    @NotNull
     private String generateAliasQuery() {
-        final Set<String> allowedLocations = this.factory.getAllowedAliasLocations();
+        Set<String> allowedLocations = this.factory.getAllowedAliasLocations();
 
         StringBuilder baseQuery = new StringBuilder("SELECT [sling:alias] FROM [nt:base] WHERE");
 
@@ -456,19 +463,19 @@ class AliasHandler {
      * Load alias given a resource
      */
     private boolean loadAlias(
-            final Resource resource,
-            Map<String, Map<String, Collection<String>>> map,
-            List<String> conflictingAliases,
-            List<String> invalidAliases) {
+            @NotNull Resource resource,
+            @NotNull Map<String, Map<String, Collection<String>>> map,
+            @Nullable List<String> conflictingAliases,
+            @Nullable List<String> invalidAliases) {
 
         // resource containing the alias
-        final Resource containingResource = getResourceToBeAliased(resource);
+        Resource containingResource = getResourceToBeAliased(resource);
 
         if (containingResource == null) {
             log.warn("containingResource is null for alias on {}, skipping.", resource.getPath());
             return false;
         } else {
-            final Resource parent = containingResource.getParent();
+            Resource parent = containingResource.getParent();
 
             if (parent == null) {
                 log.warn(
@@ -477,7 +484,7 @@ class AliasHandler {
                         resource.getPath());
                 return false;
             } else {
-                final String[] aliasArray = resource.getValueMap().get(ResourceResolverImpl.PROP_ALIAS, String[].class);
+                String[] aliasArray = resource.getValueMap().get(ResourceResolverImpl.PROP_ALIAS, String[].class);
                 if (aliasArray == null) {
                     return false;
                 } else {
@@ -497,19 +504,19 @@ class AliasHandler {
      * Load alias given an alias array, return success flag.
      */
     private boolean loadAliasFromArray(
-            final String[] aliasArray,
-            Map<String, Map<String, Collection<String>>> map,
-            List<String> conflictingAliases,
-            List<String> invalidAliases,
-            final String resourceName,
-            final String parentPath) {
+            @Nullable String[] aliasArray,
+            @NotNull Map<String, Map<String, Collection<String>>> map,
+            @Nullable List<String> conflictingAliases,
+            @Nullable List<String> invalidAliases,
+            @NotNull String resourceName,
+            @NotNull String parentPath) {
 
         boolean hasAlias = false;
 
         log.debug("Found alias, total size {}", aliasArray.length);
 
         // the order matters here, the first alias in the array must come first
-        for (final String alias : aliasArray) {
+        for (String alias : aliasArray) {
             if (isAliasInvalid(alias)) {
                 long invalids = detectedInvalidAliases.incrementAndGet();
                 log.warn(
@@ -558,10 +565,10 @@ class AliasHandler {
      * Given a resource, check whether the name is "jcr:content", in which case return the parent resource
      *
      * @param resource resource to check
-     * @return parent of jcr:content resource (may be null), otherwise the resource itself
+     * @return parent of jcr:content resource (can be null), otherwise the resource itself
      */
     @Nullable
-    private Resource getResourceToBeAliased(Resource resource) {
+    private Resource getResourceToBeAliased(@NotNull Resource resource) {
         if (JCR_CONTENT.equals(resource.getName())) {
             return resource.getParent();
         } else {
@@ -572,24 +579,30 @@ class AliasHandler {
     /**
      * Check alias syntax
      */
-    private boolean isAliasInvalid(String alias) {
-        boolean invalid = alias.equals("..") || alias.equals(".") || alias.isEmpty();
-        if (!invalid) {
-            for (final char c : alias.toCharArray()) {
-                // invalid if / or # or a ?
-                if (c == '/' || c == '#' || c == '?') {
-                    invalid = true;
-                    break;
+    private boolean isAliasInvalid(@Nullable String alias) {
+        boolean invalid;
+        if (alias == null) {
+            invalid = true;
+        } else {
+            invalid = alias.equals("..") || alias.equals(".") || alias.isEmpty();
+            if (!invalid) {
+                for (char c : alias.toCharArray()) {
+                    // invalid if / or # or a ?
+                    if (c == '/' || c == '#' || c == '?') {
+                        invalid = true;
+                        break;
+                    }
                 }
             }
         }
         return invalid;
     }
 
-    private Iterator<Resource> queryUnpaged(String query, ResourceResolver resolver) {
+    @NotNull
+    private Iterator<Resource> queryUnpaged(@NotNull String query, @NotNull ResourceResolver resolver) {
         log.debug("start alias query: {}", query);
         long queryStart = System.nanoTime();
-        final Iterator<Resource> it = resolver.findResources(query, "JCR-SQL2");
+        Iterator<Resource> it = resolver.findResources(query, "JCR-SQL2");
         long queryElapsed = System.nanoTime() - queryStart;
         log.debug("end alias query; elapsed {}ms", TimeUnit.NANOSECONDS.toMillis(queryElapsed));
         return it;
@@ -597,7 +610,7 @@ class AliasHandler {
 
     private final AtomicLong lastTimeLogged = new AtomicLong(-1);
 
-    void logDisableAliasOptimization(final Exception e) {
+    void logDisableAliasOptimization(@Nullable Exception e) {
         if (e != null) {
             log.error(
                     "Unexpected problem during initialization of optimize alias resolution. Therefore disabling optimize alias resolution. Please fix the problem.",

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -315,32 +315,33 @@ class AliasHandler {
         }
     }
 
-    public @NotNull Map<String, Collection<String>> getAliasMap(final String parentPath) {
+    public @NotNull Map<String, Collection<String>> getAliasMap(@Nullable final String parentPath) {
         Map<String, Collection<String>> result = this.aliasMapsMap != UNITIALIZED_MAP
                 ? getAliasMapFromCache(parentPath)
                 : getAliasMapFromRepo(parentPath);
         return result != null ? result : Collections.emptyMap();
     }
 
-    private @Nullable Map<String, Collection<String>> getAliasMapFromCache(final String parentPath) {
+    private @Nullable Map<String, Collection<String>> getAliasMapFromCache(@Nullable final String parentPath) {
         return aliasMapsMap.get(parentPath);
     }
 
     // TODO: there's an opportunity for optimization when the caller already has a Resource
-    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(final String parentPath) {
+    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable final String parentPath) {
 
-        Map<String, Collection<String>> result = null;
+        if (parentPath == null) {
+            return null;
+        } else {
+            try (final ResourceResolver resolver =
+                    factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo(SERVICE_USER))) {
 
-        try (final ResourceResolver resolver =
-                factory.getServiceResourceResolver(factory.getServiceUserAuthenticationInfo(SERVICE_USER))) {
-
-            Resource parent = resolver.getResource(parentPath);
-            result = getAliasMapFromRepo(parent);
-        } catch (LoginException ex) {
-            log.error("Could not obtain resolver", ex);
+                Resource parent = resolver.getResource(parentPath);
+                return getAliasMapFromRepo(parent);
+            } catch (LoginException ex) {
+                log.error("Could not obtain resolver", ex);
+                return null;
+            }
         }
-
-        return result;
     }
 
     private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable final Resource parent) {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -343,7 +343,7 @@ class AliasHandler {
         return result;
     }
 
-    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(final Resource parent) {
+    private @Nullable Map<String, Collection<String>> getAliasMapFromRepo(@Nullable final Resource parent) {
 
         Map<String, Collection<String>> result = null;
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -200,7 +200,6 @@ public class MapEntries implements MapEntriesHandler, ResourceChangeListener, Ex
             if (resource != null) {
 
                 boolean vanityPathChanged = false;
-                boolean aliasChanged = false;
 
                 if (isValidVanityPath) {
                     // we remove the old vanity path first
@@ -215,7 +214,7 @@ public class MapEntries implements MapEntriesHandler, ResourceChangeListener, Ex
                     vanityPathChanged |= vph.doAddVanity(contentRsrc != null ? contentRsrc : resource);
                 }
 
-                aliasChanged |= ah.doUpdateAlias(resource);
+                boolean aliasChanged = ah.doUpdateAlias(resource);
                 return vanityPathChanged || aliasChanged;
             }
         } finally {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -232,7 +232,6 @@ public class ResourceMapperImpl implements ResourceMapper {
     }
 
     private void resolveAliases(Resource res, PathGenerator pathBuilder) {
-        Resource current = res;
         String path = res.getPath();
 
         while (path != null) {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -19,7 +19,6 @@
 package org.apache.sling.resourceresolver.impl.mapping;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -33,7 +32,6 @@ import org.apache.sling.api.resource.mapping.ResourceMapper;
 import org.apache.sling.resourceresolver.impl.JcrNamespaceMangler;
 import org.apache.sling.resourceresolver.impl.ResourceResolverImpl;
 import org.apache.sling.resourceresolver.impl.helper.ResourceDecoratorTracker;
-import org.apache.sling.resourceresolver.impl.helper.ResourceResolverControl;
 import org.apache.sling.resourceresolver.impl.helper.URI;
 import org.apache.sling.resourceresolver.impl.helper.URIException;
 import org.apache.sling.resourceresolver.impl.params.ParsedParameters;
@@ -236,71 +234,34 @@ public class ResourceMapperImpl implements ResourceMapper {
     private void resolveAliases(Resource res, PathGenerator pathBuilder) {
         Resource current = res;
         String path = res.getPath();
-        if (this.mapEntries.isOptimizeAliasResolutionEnabled()) {
-            // this code path avoids any creation of Sling Resource objects
-            while (path != null) {
-                Collection<String> aliases = Collections.emptyList();
-                // read alias only if we can read the resources and it's not a jcr:content leaf
-                if (!path.endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
-                    aliases = readAliasesOptimized(path);
-                }
-                // build the path from the name segments or aliases
-                pathBuilder.insertSegment(aliases, ResourceUtil.getName(path));
-                path = ResourceUtil.getParent(path);
-                if ("/".equals(path)) {
-                    path = null;
-                }
+
+        while (path != null) {
+            Collection<String> aliases = Collections.emptyList();
+            // read alias only if we can read the resources and it's not a jcr:content leaf
+            if (!path.endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
+                aliases = readAliases(path);
             }
-        } else {
-            // while here there Resources are resolved
-            while (path != null) {
-                List<String> aliases = Collections.emptyList();
-                // read alias only if we can read the resources and it's not a jcr:content leaf
-                if (current != null && !path.endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
-                    aliases = readAliases(path, current);
-                }
-                // build the path from the name segments or aliases
-                pathBuilder.insertSegment(aliases, ResourceUtil.getName(path));
-                path = ResourceUtil.getParent(path);
-                if ("/".equals(path)) {
-                    path = null;
-                } else if (path != null) {
-                    current = resolver.resolve(path);
-                }
+            // build the path from the name segments or aliases
+            pathBuilder.insertSegment(aliases, ResourceUtil.getName(path));
+            path = ResourceUtil.getParent(path);
+            if ("/".equals(path)) {
+                path = null;
             }
         }
     }
 
     /**
-     * Resolve the aliases for the given resource by directly reading the sling:alias property
-     * @param path the path of the resource
-     * @param current the resource
-     * @return
+     * Resolve the aliases for the given resource by a lookup in MapEntries
+     * @param path path for which to lookup aliases
+     * @return collection of aliases for that resource
      */
-    private List<String> readAliases(String path, Resource current) {
-        logger.debug("map: Optimize Alias Resolution is Disabled");
-        String[] aliases =
-                ResourceResolverControl.getProperty(current, ResourceResolverImpl.PROP_ALIAS, String[].class);
-        if (aliases == null || aliases.length == 0) return Collections.emptyList();
-        if (aliases.length == 1) return Collections.singletonList(aliases[0]);
-        return Arrays.asList(aliases);
-    }
-
-    /**
-     * Resolve teh aliases for the given resource by a lookup in the mapEntries structure, avoiding
-     * any repository access
-     * @param path
-     * @return
-     */
-    private Collection<String> readAliasesOptimized(String path) {
-        logger.debug("map: Optimize Alias Resolution is Enabled");
+    private Collection<String> readAliases(String path) {
         String parentPath = ResourceUtil.getParent(path);
         if (parentPath == null) {
             return Collections.emptyList();
+        } else {
+            return mapEntries.getAliasMap(parentPath).getOrDefault(ResourceUtil.getName(path), Collections.emptyList());
         }
-        String name = ResourceUtil.getName(path);
-
-        return mapEntries.getAliasMap(parentPath).getOrDefault(name, Collections.emptyList());
     }
 
     private void populateMappingsFromMapEntries(

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -1174,6 +1174,11 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
     }
 
     @Test
+    public void test_doRemoveAliasNullResolver() throws Exception {
+        removeAlias(mapEntries, null, "/x", null, NOOP);
+    }
+
+    @Test
     public void test_initAliasesAfterDispose() {
         AliasHandler ah = mapEntries.ah;
         mapEntries.dispose();

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -547,15 +547,14 @@ public class ResourceMapperImplTest {
      */
     private void assertResourceResolverAccess(
             ResourceResolverImpl spyResolver, ResourceMapperImpl mapper, String path) {
-        int pathSegments = (int) path.chars().filter(c -> c == '/').count();
         mapper.getMapping(path);
-        if (this.optimiseAliasResolution) {
-            Mockito.verify(spyResolver, Mockito.times(0)).resolve(Mockito.any(String.class));
-            Mockito.verify(spyResolver, Mockito.times(1)).resolveInternal(Mockito.any(String.class), Mockito.anyMap());
-        } else {
-            Mockito.verify(spyResolver, Mockito.times(pathSegments - 1)).resolve(Mockito.any(String.class));
-            Mockito.verify(spyResolver, Mockito.times(pathSegments))
-                    .resolveInternal(Mockito.any(String.class), Mockito.anyMap());
+        Mockito.verify(spyResolver, Mockito.times(0)).resolve(Mockito.any(String.class));
+        Mockito.verify(spyResolver, Mockito.times(1)).resolveInternal(Mockito.any(String.class), Mockito.anyMap());
+        if (!this.optimiseAliasResolution) {
+            // int pathSegments = (int) path.chars().filter(c -> c == '/').count();
+            // we should see here multiple calls to getResource, but the alias
+            // handler uses a different instance that is acquired for each interaction
+            // maybe something to check
         }
         Mockito.clearInvocations(spyResolver);
     }


### PR DESCRIPTION
This removes logic from `ResourceMapperImpl` that previously took two different code paths, depending on the mode.

To get there, `AliasHandler` now handles `getAliasMap` even when the alias cache is not in use.

Note: for that, it uses its own resolver instance, thus the test in `ResourceMapperImplTest` does not "work" anymore (code removed for now). Suggestions how to resurrect that check (do we even need it anymore?) are welcome.