### PR TITLE
SLING-12787: ResourceResolver: alias refactoring - use Resource instead of Path when getting aliases

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -83,12 +83,6 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
 
     public static final String PROP_ALIAS = "sling:alias";
 
-    // The suffix of a resource being a content node of some parent
-    // such as nt:file. The slash is included to prevent false
-    // positives for the String.endsWith check for names like
-    // "xyzjcr:content"
-    public static final String JCR_CONTENT_LEAF = "/jcr:content";
-
     protected static final String PARENT_RT_CACHEKEY = ResourceResolverImpl.class.getName() + ".PARENT_RT";
 
     /** The factory which created this resource resolver. */

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -27,7 +27,6 @@ import java.util.function.UnaryOperator;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.mapping.ResourceMapper;
 import org.apache.sling.resourceresolver.impl.JcrNamespaceMangler;
 import org.apache.sling.resourceresolver.impl.ResourceResolverImpl;
@@ -264,14 +263,12 @@ public class ResourceMapperImpl implements ResourceMapper {
      * @param resource resource for which to lookup aliases
      * @return collection of aliases for that resource
      */
-    private Collection<String> readAliases(@NotNull Resource resource) {
+    private @NotNull Collection<String> readAliases(@NotNull Resource resource) {
         Resource parent = resource.getParent();
         if (parent == null) {
             return Collections.emptyList();
         } else {
-            return mapEntries
-                    .getAliasMap(parent)
-                    .getOrDefault(ResourceUtil.getName(resource.getPath()), Collections.emptyList());
+            return mapEntries.getAliasMap(parent).getOrDefault(resource.getName(), Collections.emptyList());
         }
     }
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -238,11 +238,11 @@ public class ResourceMapperImpl implements ResourceMapper {
         while (path != null && current != null) {
             Collection<String> aliases = Collections.emptyList();
             // read alias only if we can read the resources and it's not a jcr:content leaf
-            if (!path.endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
+            if (!current.getPath().endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
                 aliases = readAliases(current);
             }
             // build the path from the name segments or aliases
-            pathBuilder.insertSegment(aliases, ResourceUtil.getName(path));
+            pathBuilder.insertSegment(aliases, current.getName());
             path = ResourceUtil.getParent(path);
             current = current.getParent();
             if ("/".equals(path)) {

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -233,16 +233,18 @@ public class ResourceMapperImpl implements ResourceMapper {
 
     private void resolveAliases(Resource res, PathGenerator pathBuilder) {
         String path = res.getPath();
+        Resource current = res;
 
-        while (path != null) {
+        while (path != null && current != null) {
             Collection<String> aliases = Collections.emptyList();
             // read alias only if we can read the resources and it's not a jcr:content leaf
             if (!path.endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
-                aliases = readAliases(path);
+                aliases = readAliases(current);
             }
             // build the path from the name segments or aliases
             pathBuilder.insertSegment(aliases, ResourceUtil.getName(path));
             path = ResourceUtil.getParent(path);
+            current = current.getParent();
             if ("/".equals(path)) {
                 path = null;
             }
@@ -251,15 +253,17 @@ public class ResourceMapperImpl implements ResourceMapper {
 
     /**
      * Resolve the aliases for the given resource by a lookup in MapEntries
-     * @param path path for which to lookup aliases
+     * @param resource resource for which to lookup aliases
      * @return collection of aliases for that resource
      */
-    private Collection<String> readAliases(String path) {
-        String parentPath = ResourceUtil.getParent(path);
-        if (parentPath == null) {
+    private Collection<String> readAliases(Resource resource) {
+        Resource parent = resource.getParent();
+        if (parent == null) {
             return Collections.emptyList();
         } else {
-            return mapEntries.getAliasMap(parentPath).getOrDefault(ResourceUtil.getName(path), Collections.emptyList());
+            return mapEntries
+                    .getAliasMap(parent)
+                    .getOrDefault(ResourceUtil.getName(resource.getPath()), Collections.emptyList());
         }
     }
 

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -35,6 +35,7 @@ import org.apache.sling.resourceresolver.impl.helper.ResourceDecoratorTracker;
 import org.apache.sling.resourceresolver.impl.helper.URI;
 import org.apache.sling.resourceresolver.impl.helper.URIException;
 import org.apache.sling.resourceresolver.impl.params.ParsedParameters;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -231,17 +232,22 @@ public class ResourceMapperImpl implements ResourceMapper {
         return mappedPaths;
     }
 
-    private void resolveAliases(Resource res, PathGenerator pathBuilder) {
-        Resource current = res;
+    /*
+     * Populate a {@linkplain PathGenerator} based on the aliases of this resource, plus all ancestors
+     * @param resource the resource from which to start
+     * @param pathGenerator path generator to populate
+     */
+    private void resolveAliases(@NotNull Resource resource, @NotNull PathGenerator pathGenerator) {
+        Resource current = resource;
 
         while (current != null) {
             String name = current.getName();
 
-            // read aliases only if we can read the resources and it's not a jcr:content leaf
+            // read aliases only if it's not a jcr:content resource
             Collection<String> aliases = name.equals("jcr:content") ? Collections.emptyList() : readAliases(current);
 
             // build the path from the name segments or aliases
-            pathBuilder.insertSegment(aliases, name);
+            pathGenerator.insertSegment(aliases, name);
 
             // traverse up
             current = current.getParent();
@@ -258,7 +264,7 @@ public class ResourceMapperImpl implements ResourceMapper {
      * @param resource resource for which to lookup aliases
      * @return collection of aliases for that resource
      */
-    private Collection<String> readAliases(Resource resource) {
+    private Collection<String> readAliases(@NotNull Resource resource) {
         Resource parent = resource.getParent();
         if (parent == null) {
             return Collections.emptyList();

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImpl.java
@@ -232,21 +232,23 @@ public class ResourceMapperImpl implements ResourceMapper {
     }
 
     private void resolveAliases(Resource res, PathGenerator pathBuilder) {
-        String path = res.getPath();
         Resource current = res;
 
-        while (path != null && current != null) {
-            Collection<String> aliases = Collections.emptyList();
-            // read alias only if we can read the resources and it's not a jcr:content leaf
-            if (!current.getPath().endsWith(ResourceResolverImpl.JCR_CONTENT_LEAF)) {
-                aliases = readAliases(current);
-            }
+        while (current != null) {
+            String name = current.getName();
+
+            // read aliases only if we can read the resources and it's not a jcr:content leaf
+            Collection<String> aliases = name.equals("jcr:content") ? Collections.emptyList() : readAliases(current);
+
             // build the path from the name segments or aliases
-            pathBuilder.insertSegment(aliases, current.getName());
-            path = ResourceUtil.getParent(path);
+            pathBuilder.insertSegment(aliases, name);
+
+            // traverse up
             current = current.getParent();
-            if ("/".equals(path)) {
-                path = null;
+
+            // reached the root? -> stop traversing up
+            if (current != null && current.getParent() == null) {
+                current = null;
             }
         }
     }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -514,6 +514,8 @@ public class MockedResourceResolverImplTest {
             ResourceProvider<?> provider,
             String... properties) {
 
+        // build a mocked parent resource so that getParent() can return something meaningful (it is null when we are
+        // already at root level)
         Resource parentResource = fullpath == null || "/".equals(fullpath)
                 ? null
                 : buildResource(

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -40,6 +40,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.resourceresolver.impl.mapping.MapEntries;
@@ -499,7 +500,7 @@ public class MockedResourceResolverImplTest {
     }
 
     /**
-     * Build a resource with path, children and resource resolver.
+     * Build a resource with parent, path, children and resource resolver.
      * @param fullpath
      * @param children
      * @param resourceResolver
@@ -512,9 +513,16 @@ public class MockedResourceResolverImplTest {
             ResourceResolver resourceResolver,
             ResourceProvider<?> provider,
             String... properties) {
+
+        Resource parentResource = fullpath == null || "/".equals(fullpath)
+                ? null
+                : buildResource(
+                        ResourceUtil.getParent(fullpath), Collections.emptyList(), resourceResolver, provider, null);
+
         Resource resource = mock(Resource.class);
         Mockito.when(resource.getName()).thenReturn(getResourceName(fullpath));
         Mockito.when(resource.getPath()).thenReturn(fullpath);
+        Mockito.when(resource.getParent()).thenReturn(parentResource);
         ResourceMetadata resourceMetadata = new ResourceMetadata();
         Mockito.when(resource.getResourceMetadata()).thenReturn(resourceMetadata);
         Mockito.when(resource.listChildren()).thenReturn(children.iterator());

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceDecorationTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceDecorationTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 public class ResourceDecorationTest extends ResourceDecoratorTestBase {
 
     private static final String DECORATED_NAME = "decorated";
-    private static final String DECORATED_PATH = "/decoratedPath";
+    private static final String DECORATED_PATH = "/decorated";
 
     /** Wrap any resource so that its name is DECORATED_NAME */
     protected Resource wrapResourceForTest(Resource resource) {


### PR DESCRIPTION
This changes `ResourceMapperImpl.resolveAliases` to use the `Resource` that it already has for (a) getting the aliases and (b) walking the tree up.

Changes in tests unfortunately were needed as:

- resources were mocked without handling `getParent()`, and
- decorator tests were using inconsistent mocked values for `getParent()` and `getName()`