### PR TITLE
SLING-12804: alias refactoring - improve test coverage of query statements

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -167,7 +167,7 @@ class AliasHandler {
     }
 
     boolean doAddAlias(@NotNull Resource resource) {
-        if (this.aliasMapsMap != UNITIALIZED_MAP) {
+        if (usesCache()) {
             return loadAlias(resource, this.aliasMapsMap, null, null);
         } else {
             return false;
@@ -186,7 +186,7 @@ class AliasHandler {
             @NotNull String contentPath,
             @Nullable String path,
             @NotNull Runnable notifyOfChange) {
-        if (this.aliasMapsMap != UNITIALIZED_MAP) {
+        if (usesCache()) {
             return removeAliasInMap(resolver, contentPath, path, notifyOfChange);
         } else {
             return false;
@@ -280,7 +280,7 @@ class AliasHandler {
      * @return {@code true} if any change
      */
     boolean doUpdateAlias(@NotNull Resource resource) {
-        if (this.aliasMapsMap != UNITIALIZED_MAP) {
+        if (usesCache()) {
             return doUpdateAliasInMap(resource);
         } else {
             return false;
@@ -322,16 +322,14 @@ class AliasHandler {
     }
 
     public @NotNull Map<String, Collection<String>> getAliasMap(@Nullable String parentPath) {
-        Map<String, Collection<String>> result = this.aliasMapsMap != UNITIALIZED_MAP
-                ? getAliasMapFromCache(parentPath)
-                : getAliasMapFromRepo(parentPath);
+        Map<String, Collection<String>> result =
+                usesCache() ? getAliasMapFromCache(parentPath) : getAliasMapFromRepo(parentPath);
         return result != null ? result : Collections.emptyMap();
     }
 
     public @NotNull Map<String, Collection<String>> getAliasMap(@NotNull Resource parent) {
-        Map<String, Collection<String>> result = this.aliasMapsMap != UNITIALIZED_MAP
-                ? getAliasMapFromCache(parent.getPath())
-                : getAliasMapFromRepo(parent);
+        Map<String, Collection<String>> result =
+                usesCache() ? getAliasMapFromCache(parent.getPath()) : getAliasMapFromRepo(parent);
         return result != null ? result : Collections.emptyMap();
     }
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -447,6 +447,7 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
 
         new MapEntries(resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, metrics);
 
+        assertTrue("seems no alias query was made", !queryMade.isEmpty());
         String match1 = "(isdescendantnode('/a') OR isdescendantnode('/''b'''))";
         String match2 = "(isdescendantnode('/''b''') OR isdescendantnode('/a'))";
         String actual = queryMade.iterator().next();

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -355,7 +355,7 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
 
         when(resourceResolver.findResources(anyString(), eq("JCR-SQL2")))
                 .thenAnswer((Answer<Iterator<Resource>>) invocation -> {
-                    String query = invocation.getArguments()[0].toString();
+                    String query = invocation.getArgument(0);
                     if (query.equals(AQ_SIMPLE) || matchesPagedQuery(query)) {
                         return Arrays.asList(result, secondResult).iterator();
                     } else {
@@ -393,7 +393,7 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
 
         when(resourceResolver.findResources(anyString(), eq("JCR-SQL2")))
                 .thenAnswer((Answer<Iterator<Resource>>) invocation -> {
-                    String query = invocation.getArguments()[0].toString();
+                    String query = invocation.getArgument(0);
                     if (query.equals(AQ_SIMPLE) || matchesPagedQuery(query)) {
                         return List.of(node, content).iterator();
                     } else {

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -307,9 +307,9 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
             String path = invocation.getArgument(0);
             if (path.equals(parent.getPath())) {
                 return parent;
-            } else if (path.equals(result)) {
+            } else if (path.equals(result.getPath())) {
                 return result;
-            } else if (path.equals(content)) {
+            } else if (path.equals(content.getPath())) {
                 return content;
             } else {
                 return null;

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -1281,17 +1281,16 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
     // utilities for testing alias queries
 
     // used for paged query of all
-    private static final String AQ_PAGED_START = "SELECT [sling:alias] FROM [nt:base] WHERE "
-            + QueryBuildHelper.excludeSystemPath()
-            + " AND [sling:alias] IS NOT NULL AND FIRST([sling:alias]) >= '";
+    private static final String AQ_PAGED_START =
+            "SELECT [sling:alias] FROM [nt:base] WHERE NOT isdescendantnode('/jcr:system') AND [sling:alias] IS NOT NULL AND FIRST([sling:alias]) >= '";
     private static final String AQ_PAGED_END = "' ORDER BY FIRST([sling:alias])";
 
     private static final Pattern AQ_PAGED_PATTERN =
             Pattern.compile(Pattern.quote(AQ_PAGED_START) + "(?<path>\\p{Alnum}*)" + Pattern.quote(AQ_PAGED_END));
 
     // used when paged query not available
-    private static final String AQ_SIMPLE = "SELECT [sling:alias] FROM [nt:base] WHERE "
-            + QueryBuildHelper.excludeSystemPath() + " AND [sling:alias] IS NOT NULL";
+    private static final String AQ_SIMPLE =
+            "SELECT [sling:alias] FROM [nt:base] WHERE NOT isdescendantnode('/jcr:system') AND [sling:alias] IS NOT NULL";
 
     // sanity test on matcher
     @Test


### PR DESCRIPTION
This mainly improves test coverage wrt what queries are used, and how `AliasHandler` handles exceptions.

It also adds test coverage for the "uncached" case (where no query is generated at all, instead the Sling resource tree is walked).

This also includes two minor refactorings in `AliasHandler`.