### PR TITLE
alias refactoring - use Resource instead of Path when getting aliases - fix recursion when Resource parent not accessible

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -83,12 +83,6 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
 
     public static final String PROP_ALIAS = "sling:alias";
 
-    // The suffix of a resource being a content node of some parent
-    // such as nt:file. The slash is included to prevent false
-    // positives for the String.endsWith check for names like
-    // "xyzjcr:content"
-    public static final String JCR_CONTENT_LEAF = "/jcr:content";
-
     protected static final String PARENT_RT_CACHEKEY = ResourceResolverImpl.class.getName() + ".PARENT_RT";
 
     /** The factory which created this resource resolver. */

--- a/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/MockedResourceResolverImplTest.java
@@ -40,6 +40,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.resourceresolver.impl.mapping.MapEntries;
@@ -499,7 +500,7 @@ public class MockedResourceResolverImplTest {
     }
 
     /**
-     * Build a resource with path, children and resource resolver.
+     * Build a resource with parent, path, children and resource resolver.
      * @param fullpath
      * @param children
      * @param resourceResolver
@@ -512,9 +513,18 @@ public class MockedResourceResolverImplTest {
             ResourceResolver resourceResolver,
             ResourceProvider<?> provider,
             String... properties) {
+
+        // build a mocked parent resource so that getParent() can return something meaningful (it is null when we are
+        // already at root level)
+        Resource parentResource = fullpath == null || "/".equals(fullpath)
+                ? null
+                : buildResource(
+                        ResourceUtil.getParent(fullpath), Collections.emptyList(), resourceResolver, provider, null);
+
         Resource resource = mock(Resource.class);
         Mockito.when(resource.getName()).thenReturn(getResourceName(fullpath));
         Mockito.when(resource.getPath()).thenReturn(fullpath);
+        Mockito.when(resource.getParent()).thenReturn(parentResource);
         ResourceMetadata resourceMetadata = new ResourceMetadata();
         Mockito.when(resource.getResourceMetadata()).thenReturn(resourceMetadata);
         Mockito.when(resource.listChildren()).thenReturn(children.iterator());

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceDecorationTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceDecorationTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 public class ResourceDecorationTest extends ResourceDecoratorTestBase {
 
     private static final String DECORATED_NAME = "decorated";
-    private static final String DECORATED_PATH = "/decoratedPath";
+    private static final String DECORATED_PATH = "/decorated";
 
     /** Wrap any resource so that its name is DECORATED_NAME */
     protected Resource wrapResourceForTest(Resource resource) {

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceDecorationTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceDecorationTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 public class ResourceDecorationTest extends ResourceDecoratorTestBase {
 
     private static final String DECORATED_NAME = "decorated";
-    private static final String DECORATED_PATH = "/decorated";
+    private static final String DECORATED_PATH = "/decoratedPath";
 
     /** Wrap any resource so that its name is DECORATED_NAME */
     protected Resource wrapResourceForTest(Resource resource) {


### PR DESCRIPTION
This fixes the case where the parent of a Resource is null, which previously aborted the recursion, returning an incorrectly populated  `PathGenerator`.

The code now walks the (String) path again, but continues to use `Resource`s as long as possible.