### PR TITLE
SLING-12795: align behavior for cached ('optimized') and non-cached case

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/AliasHandler.java
@@ -289,7 +289,7 @@ class AliasHandler {
 
     private boolean doUpdateAliasInMap(@NotNull Resource resource) {
 
-        // resource containing the alias
+        // resource to which the alias applies
         Resource containingResource = getResourceToBeAliased(resource);
 
         if (containingResource != null) {
@@ -361,7 +361,16 @@ class AliasHandler {
             Map<String, Map<String, Collection<String>>> localMap = new HashMap<>();
             List<String> throwAwayDiagnostics = new ArrayList<>();
             for (Resource child : parent.getChildren()) {
-                loadAlias(child, localMap, throwAwayDiagnostics, throwAwayDiagnostics);
+                // ignore jcr:content nodes, they get special treatment
+                if (!JCR_CONTENT.equals(child.getName())) {
+                    loadAlias(child, localMap, throwAwayDiagnostics, throwAwayDiagnostics);
+                    Resource childContentNode = child.getChild(JCR_CONTENT);
+                    // check for jcr:content child node...
+                    if (childContentNode != null) {
+                        // and apply its aliases to the parent node
+                        loadAlias(childContentNode, localMap, throwAwayDiagnostics, throwAwayDiagnostics);
+                    }
+                }
             }
             result = localMap.get(parent.getPath());
         }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/ResourceMapperImplTest.java
@@ -253,33 +253,17 @@ public class ResourceMapperImplTest {
     /**
      * Validates that a jcr:content resource cannot be aliased, but instead its parent resource is
      *
-     * NOTE: There is a bug in this behavior:
-     * * if optimiseAliasResolution is true, the behavior is working as expected
-     * * if optimiseAliasResolution is false the aliasing is not working
-     *
-     * This bug exists for quite some time (and therefore should be considered a feature by now), so
-     * this test expects different outcome in this case. Also see SLING-12025
-     *
      * @throws LoginException
      */
     @Test
     public void mapJcrContentResourceWithAlias() {
 
-        if (this.optimiseAliasResolution) {
-            ExpectedMappings.existingResource("/content1/jcr:content")
-                    .singleMapping("/jcr:content-alias/jcr:content")
-                    .singleMappingWithRequest("/app/jcr:content-alias/jcr:content")
-                    .allMappings("/jcr:content-alias/jcr:content", "/content1/jcr:content")
-                    .allMappingsWithRequest("/app/content1/jcr:content", "/app/jcr:content-alias/jcr:content")
-                    .verify(resolver, req);
-        } else {
-            ExpectedMappings.existingResource("/content1/jcr:content")
-                    .singleMapping("/content1/jcr:content")
-                    .singleMappingWithRequest("/app/content1/jcr:content")
-                    .allMappings("/content1/jcr:content")
-                    .allMappingsWithRequest("/app/content1/jcr:content")
-                    .verify(resolver, req);
-        }
+        ExpectedMappings.existingResource("/content1/jcr:content")
+                .singleMapping("/jcr:content-alias/jcr:content")
+                .singleMappingWithRequest("/app/jcr:content-alias/jcr:content")
+                .allMappings("/jcr:content-alias/jcr:content", "/content1/jcr:content")
+                .allMappingsWithRequest("/app/content1/jcr:content", "/app/jcr:content-alias/jcr:content")
+                .verify(resolver, req);
     }
 
     /**


### PR DESCRIPTION
This aligns the behaviour for the two cases. Reminder: the uncached case ("non-optimized") will be needed later on when we introduce the async loading.

(and aligning the documentation will be a separate PR)