### PR TITLE
SLING-12884: ResourceResolver: refactor mocking in AliasMapEntriesTest

### DIFF
--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -977,7 +977,7 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
         assertEquals(0, aliasMap.size());
 
         Resource parent = createMockedResource("/");
-        Resource result = createMockedResource("/parent");
+        Resource result = createMockedResource(parent, "parent");
 
         when(result.getValueMap()).thenReturn(buildValueMap());
 


### PR DESCRIPTION
This reduces test boilerplace and also ensures correctness wrt parent/child relationships.

The latter change caused two tests to fail, as they did not implement getChild* correctly. See

https://github.com/apache/sling-org-apache-sling-resourceresolver/pull/189/commits/f695598f5d366b3df398bc40492ae9164ffc0459
