### PR TITLE
SLING-12747: add logging to iteration loop in ResourceResolverImpl

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -350,13 +350,18 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         // loop while finding internal or external redirect into the
         // content out of the virtual host mapping tree
         // the counter is to ensure we are not caught in an endless loop here
-        // TODO: might do better to be able to log the loop and help the user
-        for (int i = 0; i < 100; i++) {
+
+        final int maxIterations = 100;
+        int iterationsLeft = maxIterations;
+
+        while (iterationsLeft > 0) {
+            iterationsLeft -= 1;
 
             String[] mappedPath = null;
 
             final Iterator<MapEntry> mapEntriesIterator =
                     this.factory.getMapEntries().getResolveMapsIterator(requestPath);
+
             while (mapEntriesIterator.hasNext()) {
                 final MapEntry mapEntry = mapEntriesIterator.next();
                 mappedPath = mapEntry.replace(requestPath);
@@ -368,12 +373,12 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
                                 Arrays.toString(mappedPath));
                     }
                     if (mapEntry.isInternal()) {
-                        // internal redirect
+                        // internal redirect: stop looking for further MapEntries
                         logger.debug("resolve: Redirecting internally");
                         break;
                     }
 
-                    // external redirect
+                    // external redirect: we are done
                     logger.debug("resolve: Returning external redirect");
                     return this.factory
                             .getResourceDecoratorTracker()
@@ -388,14 +393,14 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
                 break;
             }
 
-            // if the mapped path is not an URL, use this path to continue
+            // if the mapped path is not a URI, abort and use this path to continue
             if (!mappedPath[0].contains("://")) {
                 logger.debug("resolve: Mapped path is for resource tree");
                 realPathList = mappedPath;
                 break;
             }
 
-            // otherwise the mapped path is an URI and we have to try to
+            // otherwise the mapped path is a URI, and we have to try to
             // resolve that URI now, using the URI's path as the real path
             try {
                 final URI uri = new URI(mappedPath[0], false);
@@ -404,9 +409,19 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
 
                 logger.debug("resolve: Mapped path is an URL, using new request path {}", requestPath);
             } catch (final URIException use) {
-                // TODO: log and fail
+                logger.debug("resolve: failure parsing {} as URI", mappedPath[0], use);
                 throw new ResourceNotFoundException(absPath);
             }
+        }
+
+        if (iterationsLeft <= 0) {
+            // we get here if we - while following URI-shaped internal redirects -
+            // reached the maximum number of allowed iterations
+            logger.debug(
+                    "resolve: maximum number of iterations ({}) exhausted while following internal redirects, "
+                            + "continuing with last found request path: {}",
+                    maxIterations,
+                    requestPath);
         }
 
         // now we have the real path resolved from virtual host mapping


### PR DESCRIPTION
Update of https://github.com/apache/sling-org-apache-sling-resourceresolver/pull/170

- add comments to loop
- improves logging inside the loop
- add logging when max iterations exceeded

Unfortunately, this didn't have test coverage.