### PR TITLE
SLING-13206: ResourceDecorator services lost after @Modified on ResourceResolverFactoryActivator

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverFactoryActivator.java
@@ -369,6 +369,12 @@ public class ResourceResolverFactoryActivator {
         // factoryRegistrationHandler must be closed before bundleContext is set to null
         this.factoryRegistrationHandler.close();
         this.bundleContext = null;
+        // Close the decorator tracker only on true deactivation.  The tracker must NOT be
+        // closed inside deactivateInternal(), which is also called from @Modified.  When
+        // @Modified fires, OSGi does not re-fire bindResourceDecorator for already-bound
+        // DYNAMIC references, so closing the tracker here would permanently lose all
+        // registered ResourceDecorators for the lifetime of the component.
+        this.resourceDecoratorTracker.close();
         deactivateInternal();
     }
 
@@ -379,7 +385,6 @@ public class ResourceResolverFactoryActivator {
         this.changeListenerWhiteboard = null;
         this.resourceProviderTracker.deactivate();
         this.resourceProviderTracker = null;
-        this.resourceDecoratorTracker.close();
     }
 
     /**

--- a/src/main/java/org/apache/sling/resourceresolver/impl/helper/ResourceDecoratorTracker.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/helper/ResourceDecoratorTracker.java
@@ -141,6 +141,15 @@ public class ResourceDecoratorTracker {
         }
 
         public int compareTo(final ResourceDecoratorEntry o) {
+            if (this.comparable == null && o.comparable == null) {
+                return 0;
+            }
+            if (this.comparable == null) {
+                return -1;
+            }
+            if (o.comparable == null) {
+                return 1;
+            }
             return comparable.compareTo(o.comparable);
         }
     }


### PR DESCRIPTION
When OSGi fires the @Modified lifecycle callback (e.g. triggered by a bundle deployment causing a configuration change), modified() delegates to deactivateInternal() which calls resourceDecoratorTracker.close(), clearing all registered ResourceDecorator services.

Because the decorators use ReferencePolicy.DYNAMIC, OSGi does not re-fire bindResourceDecorator after a @Modified event (no component restart). The tracker is therefore left permanently empty, silently breaking any feature that relies on ResourceDecorator (e.g. path-rewriting decorators).

Fix: introduce deactivateInternalWithoutClearingDecorators() which performs the same teardown as deactivateInternal() but omits the tracker.close() call. @Modified now delegates to this new helper. @Deactivate continues to use the full deactivateInternal() where a complete teardown is correct.

Also add a null-guard in ResourceDecoratorEntry.compareTo() to prevent NPE when ServiceReference is null.