### PR TITLE
chore(deps): bump sling-bundle-parent to v66 and remove pinned JUnit versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -150,19 +150,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updates the Maven POM to use a newer parent POM version and delegates JUnit dependency version management to the parent.

- Bumped `sling-bundle-parent` version from `62` to `66`
- Removed explicit `5.9.2` version pins from `junit-jupiter-api`, `junit-jupiter-engine`, and `junit-vintage-engine` dependencies, letting the parent BOM manage versions

Co-authored-by: Maia <maia@noreply>