### PR TITLE
docs: add project baseline and implementation notes to AGENTS.md and README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,24 @@
 The threat model for this project is https://github.com/apache/sling/blob/master/docs/threat-model.md .
 <!-- sling-security-default:end -->
 
+## Project and build baseline
+
+- Java version: **17** (`sling.java.version`).
+- Current development version: **2.0.5-SNAPSHOT** (after `org.apache.sling.resourceresolver-2.0.4` release).
+- Parent POM: **org.apache.sling:sling-bundle-parent:66**.
+- Standard layout: implementation in `src/main/java`, tests in `src/test/java`.
+
+## Common commands
+
+- Full build and verification: `mvn clean verify`
+- Run tests: `mvn test`
+- Build bundle artifact: `mvn clean package`
+
+## Current implementation patterns
+
+- In `MapEntries`, listener lifecycle ordering is race-safe:
+  - initialize handlers needed by `onChange` before listener registration,
+  - unregister listener before disposing dependent handlers.
+- Concurrency regressions around `MapEntries` constructor/dispose listener windows are covered in `MapEntriesTest`.
+- Prefer `StandardCharsets.US_ASCII` over string-based charset names and checked `UnsupportedEncodingException` handling in URI helper code.
+- Web console servlet (`ResourceResolverWebConsolePlugin`) handles `IOException` in `doGet`/`doPost` internally, logs failures, and returns HTTP 500 on rendering/redirect errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+read @AGENTS.md

--- a/README.md
+++ b/README.md
@@ -8,5 +8,25 @@ This module is part of the [Apache Sling](https://sling.apache.org) project.
 
 This bundle provides the Resource Resolver and Resource Resolver Factory.
 
+## Current baseline
+
+- Java version: **17**
+- Parent POM: **org.apache.sling:sling-bundle-parent:66**
+- Current development version: **2.0.5-SNAPSHOT**
+
+## Build and test
+
+- Full build and verification: `mvn clean verify`
+- Run tests: `mvn test`
+- Build bundle artifact: `mvn clean package`
+
+## Recent implementation updates
+
+- `MapEntries` listener lifecycle ordering is race-safe during construction/disposal, with regression coverage in `MapEntriesTest` (SLING-13236).
+- URI helper code uses `StandardCharsets.US_ASCII` for charset handling (SLING-13260).
+- Web console servlet (`ResourceResolverWebConsolePlugin`) handles `IOException` in `doGet`/`doPost`, logs failures, and returns HTTP 500 on rendering/redirect errors.
+- Alias and vanity-path handling received broader refactoring and startup/queue logging improvements across the `MapEntries` area.
+- Build/test dependency baseline was refreshed, including `sling-bundle-parent` 66 and updated `commons-lang3`.
+
 The `/etc/map` mapping configurations are documented on the Sling website's 
 [Mappings for Resource Resolution](https://sling.apache.org/documentation/the-sling-engine/mappings-for-resource-resolution.html) page.


### PR DESCRIPTION
Adds project context and implementation guidance to the repository documentation files.

- `AGENTS.md`: Added project/build baseline (Java 17, version 2.0.5-SNAPSHOT, parent POM), common Maven commands, and current implementation patterns covering `MapEntries` lifecycle ordering, concurrency coverage, charset handling, and web console servlet error handling.
- `README.md`: Added current baseline section, build/test commands, and a summary of recent implementation updates (SLING-13236, SLING-13260, alias/vanity-path refactoring, dependency refresh).
- `CLAUDE.md`: Added new file that references `AGENTS.md` for AI agent context.

Co-authored-by: Maia <maia@noreply>