### PR TITLE
SLING-13248 - Fix false-positive ordering check for multivalued prope…

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIterator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIterator.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.resourceresolver.impl.mapping;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
@@ -88,7 +90,11 @@ public class PagedQueryIterator implements Iterator<Resource> {
         final String[] values = resource.getValueMap().get(propertyName, defaultValue);
 
         if (values.length > 0) {
-            String value = values[0];
+            // The query orders by FIRST([propertyName]), i.e. the smallest value of a (possibly
+            // multivalued) property. The ValueMap, however, returns the values in storage order, so
+            // values[0] is not necessarily the smallest one. Use the minimum to match the query's
+            // sort key; otherwise the ordering checks below raise false positives (SLING-13266).
+            String value = Arrays.stream(values).min(Comparator.naturalOrder()).orElse(values[0]);
             if (value.compareTo(lastKey) < 0) {
                 String message = String.format(
                         "unexpected query result in page %d, property name '%s', got '%s', despite querying for > '%s'",

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -168,6 +169,37 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
                 "alias", PROPNAME, resourceResolver, "testPagedResourcesOnPageBoundaryLost '%s'", 5);
 
         checkResult(it, expected);
+    }
+
+    /**
+     * A multivalued property is returned by the query in the order of its smallest value
+     * ({@code FIRST([prop])}), but the ValueMap exposes the values in storage order. The iterator
+     * must therefore compare on the smallest value, not on {@code values[0]}: when index 0 is not
+     * the smallest value, the two orderings diverge and comparing on {@code values[0]} would raise
+     * a spurious {@link PagedQueryIterator.QueryImplementationException}.
+     */
+    @Test
+    public void testMultiValuedFirstNotAtIndexZero() {
+        // resources are returned in FIRST()/minimum order: "/aaa" < "/acs-commons"
+        Resource r1 = multiValuedResource("2025-10-14T20:32:01.481Z", "/aaa");
+        Resource r2 = multiValuedResource("/acs-commons");
+        Collection<Resource> resources = Arrays.asList(r1, r2);
+        when(resourceResolver.findResources("multivalued ''", "JCR-SQL2")).thenReturn(resources.iterator());
+        PagedQueryIterator it = new PagedQueryIterator("alias", PROPNAME, resourceResolver, "multivalued '%s'", 2000);
+
+        List<Resource> result = new ArrayList<>();
+        while (it.hasNext()) {
+            result.add(it.next());
+        }
+        assertEquals(Arrays.asList(r1, r2), result);
+    }
+
+    private static Resource multiValuedResource(String... values) {
+        ValueMap m = mock(ValueMap.class);
+        when(m.get(eq(PROPNAME), any(Object.class))).thenReturn(values);
+        Resource r = mock(Resource.class);
+        when(r.getValueMap()).thenReturn(m);
+        return r;
     }
 
     private static Collection<Resource> toResourceList(String... keys) {


### PR DESCRIPTION
…rties in PagedQueryIterator
```
18.06.2026 10:12:45.421 *ERROR* [VanityPathInitializer] org.apache.sling.resourceresolver.impl.mapping.PagedQueryIterator unexpected query result in page 0, property name 'sling:vanityPath', got '/acs-commons', last value was '2025-10-14T20:32:01.481Z'
18.06.2026 10:12:45.422 *ERROR* [VanityPathInitializer] org.apache.sling.resourceresolver.impl.mapping.VanityPathHandler vanity path initializer thread terminated with an exception
org.apache.sling.resourceresolver.impl.mapping.PagedQueryIterator$QueryImplementationException: unexpected query result in page 0, property name 'sling:vanityPath', got '/acs-commons', last value was '2025-10-14T20:32:01.481Z'
        at org.apache.sling.resourceresolver.impl.mapping.PagedQueryIterator.getNext(PagedQueryIterator.java:104) [org.apache.sling.resourceresolver:1.12.12]
        at org.apache.sling.resourceresolver.impl.mapping.PagedQueryIterator.hasNext(PagedQueryIterator.java:135) [org.apache.sling.resourceresolver:1.12.12]
        at org.apache.sling.resourceresolver.impl.mapping.VanityPathHandler.loadVanityPaths(VanityPathHandler.java:491) [org.apache.sling.resourceresolver:1.12.12]
        at org.apache.sling.resourceresolver.impl.mapping.VanityPathHandler$VanityPathInitializer.execute(VanityPathHandler.java:199) [org.apache.sling.resourceresolver:1.12.12]
        at org.apache.sling.resourceresolver.impl.mapping.VanityPathHandler$VanityPathInitializer.run(VanityPathHandler.java:186) [org.apache.sling.resourceresolver:1.12.12]
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

Because `loadVanityPaths()` threw, `vanityPathsProcessed` was never set to `true`, so the cache stayed empty for the lifetime of the resolver.
## Root cause: query order vs. storage order
`PagedQueryIterator` pages through query results and verifies, as a safety check, that they come back in ascending order. To do that it needs — for each resource — the single value the results are *ordered by*. It derived that value from the wrong source.
Two orderings are in play, and they are not the same:
1. **The order of the query results.** The query sorts with `ORDER BY FIRST([sling:vanityPath])`. Oak's `FIRST()` returns the **lexicographically smallest** value of the (multivalued) property, so the repository returns resources ordered by the *minimum* value.
2. **The order of reading the ValueMap.** The iterator used `resource.getValueMap().get(propertyName)[0]` — the value at **array index 0**. The ValueMap returns values in *storage order*, which is arbitrary; index 0 is not necessarily the smallest value.

For a single-valued property the two coincide, so the check worked. For a **multivalued** `sling:vanityPath` they diverge: the query sorts by the minimum, but the iterator compared against index 0. When a resource's index-0 value is larger than its minimum, the iterator sees an apparent "out of order" result and throws `QueryImplementationException` — even though the query order was correct.