### PR TITLE
SLING-13274: MapEntries: NPE in onChange when a resource change is de…

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/MapEntries.java
@@ -142,10 +142,15 @@ public class MapEntries implements MapEntriesHandler, ResourceChangeListener, Ex
                 this::drainAliasQueue);
         this.ah.initializeAliases();
 
-        this.registration = registerResourceChangeListener(bundleContext);
-
+        // create the vanity path handler before registering the resource change listener: the
+        // listener may be called as soon as it is registered, and onChange requires both handlers
+        // to be present (events arriving before initializeVanityPaths completes are queued and
+        // drained by the initializer)
         this.vph =
                 new VanityPathHandler(this.factory, this.resolveMapsMap, this.initializing, this::drainVanityPathQueue);
+
+        this.registration = registerResourceChangeListener(bundleContext);
+
         this.vph.initializeVanityPaths();
 
         if (metrics.isPresent()) {
@@ -293,14 +298,17 @@ public class MapEntries implements MapEntriesHandler, ResourceChangeListener, Ex
      */
     public void dispose() {
 
-        if (this.ah != null) {
-            ah.dispose();
-            ah = null;
-        }
-
+        // unregister the resource change listener before disposing the alias handler: onChange
+        // requires the handlers to be present, so they must not be torn down while the listener
+        // can still be called
         if (this.registration != null) {
             this.registration.unregister();
             this.registration = null;
+        }
+
+        if (this.ah != null) {
+            ah.dispose();
+            ah = null;
         }
 
         /*

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/MapEntriesTest.java
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChangeListener;
 import org.apache.sling.api.resource.path.Path;
 import org.apache.sling.resourceresolver.impl.ResourceResolverMetrics;
 import org.junit.After;
@@ -48,6 +50,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.event.EventAdmin;
 
 import static org.junit.Assert.assertEquals;
@@ -221,6 +224,57 @@ public class MapEntriesTest extends AbstractMappingMapEntriesTest {
                 });
 
         mapEntries.ah.initializeAliases();
+    }
+
+    // tests SLING-13236: a resource change delivered while the MapEntries constructor is still
+    // running (the listener may be called as soon as it is registered) must not cause an NPE on
+    // the not-yet-assigned VanityPathHandler
+    @Test
+    public void testChangeDeliveredDuringListenerRegistration() throws Exception {
+        final AtomicBoolean changeDelivered = new AtomicBoolean(false);
+        when(bundleContext.registerService(eq(ResourceChangeListener.class), any(ResourceChangeListener.class), any()))
+                .thenAnswer((Answer<ServiceRegistration<ResourceChangeListener>>) invocation -> {
+                    final ResourceChangeListener listener = invocation.getArgument(1);
+                    listener.onChange(List.of(new ResourceChange(ResourceChange.ChangeType.ADDED, "/resource", false)));
+                    changeDelivered.set(true);
+                    return null;
+                });
+
+        final MapEntries entries = new MapEntries(
+                resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, Optional.empty());
+        try {
+            assertTrue("change should have been delivered during listener registration", changeDelivered.get());
+        } finally {
+            entries.dispose();
+        }
+    }
+
+    // tests SLING-13236: a resource change delivered while dispose() is unregistering the
+    // listener must not cause an NPE on an already torn down AliasHandler
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testChangeDeliveredDuringDispose() throws Exception {
+        final AtomicBoolean changeDelivered = new AtomicBoolean(false);
+        when(bundleContext.registerService(eq(ResourceChangeListener.class), any(ResourceChangeListener.class), any()))
+                .thenAnswer((Answer<ServiceRegistration<ResourceChangeListener>>) invocation -> {
+                    final ResourceChangeListener listener = invocation.getArgument(1);
+                    final ServiceRegistration<ResourceChangeListener> registration =
+                            Mockito.mock(ServiceRegistration.class);
+                    Mockito.doAnswer(unregisterInvocation -> {
+                                listener.onChange(List.of(
+                                        new ResourceChange(ResourceChange.ChangeType.ADDED, "/resource", false)));
+                                changeDelivered.set(true);
+                                return null;
+                            })
+                            .when(registration)
+                            .unregister();
+                    return registration;
+                });
+
+        final MapEntries entries = new MapEntries(
+                resourceResolverFactory, bundleContext, eventAdmin, stringInterpolationProvider, Optional.empty());
+        entries.dispose();
+        assertTrue("change should have been delivered during listener unregistration", changeDelivered.get());
     }
 
     @Test


### PR DESCRIPTION
…livered during construction or disposal (backport to 1.x)

Cherry-picked from master (3b1608f) since this fix was never backported to the 1.x maintenance branch.