### PR TITLE
SLING-13275: cache the result of the getParentResourceType call (backport to 1.x)

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -97,6 +97,9 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
 
     protected final Map<ResourceTypeInformation, Boolean> resourceTypeLookupCache = new ConcurrentHashMap<>();
 
+    // Store the resourceSupertype mapping (supertype can be null)
+    protected final Map<String, Optional<String>> parentResourceTypeMap = new ConcurrentHashMap<>();
+
     private Map<String, Object> propertyMap;
 
     private volatile Exception closedResolverException;
@@ -1098,10 +1101,22 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         checkClosed();
         String resourceSuperType = null;
         if (resource != null) {
-            resourceSuperType = resource.getResourceSuperType();
-            if (resourceSuperType == null) {
-                resourceSuperType = this.getParentResourceType(resource.getResourceType());
+            if (parentResourceTypeMap.containsKey(resource.getPath())) {
+                resourceSuperType =
+                        parentResourceTypeMap.get(resource.getPath()).orElse(null);
+            } else {
+                resourceSuperType = getParentResourceTypeInternal(resource);
+                parentResourceTypeMap.put(resource.getPath(), Optional.ofNullable(resourceSuperType));
             }
+        }
+        return resourceSuperType;
+    }
+
+    String getParentResourceTypeInternal(final Resource resource) {
+        String resourceSuperType;
+        resourceSuperType = resource.getResourceSuperType();
+        if (resourceSuperType == null) {
+            resourceSuperType = this.getParentResourceType(resource.getResourceType());
         }
         return resourceSuperType;
     }
@@ -1176,6 +1191,7 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         checkClosed();
         this.control.refresh(this.context);
         resourceTypeLookupCache.clear();
+        parentResourceTypeMap.clear();
     }
 
     @Override

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverImplTest.java
@@ -62,9 +62,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 public class ResourceResolverImplTest {
@@ -751,6 +753,21 @@ public class ResourceResolverImplTest {
         assertTrue(resolver.getPropertyMap().isEmpty());
         Mockito.verify(value2, Mockito.times(1)).close();
         Mockito.verify(valueWithException, Mockito.times(1)).close();
+    }
+
+    @Test
+    public void testGetParentResourceType() {
+        final PathBasedResourceResolverImpl resolver = Mockito.spy(getPathBasedResourceResolver());
+
+        resolver.add(new SyntheticResourceWithSupertype(resolver, "/types/1", "/types/component", "/types/2"));
+        resolver.add(new SyntheticResourceWithSupertype(resolver, "/content/type1", "/types/1", null));
+
+        assertEquals("/types/2", resolver.getParentResourceType(resolver.getResource("/types/1")));
+        assertEquals("/types/2", resolver.getParentResourceType(resolver.getResource("/content/type1")));
+
+        // Ensure that the next call will be served from the cache
+        resolver.getParentResourceType(resolver.getResource("/types/1"));
+        Mockito.verify(resolver, times(2)).getParentResourceTypeInternal(any(Resource.class));
     }
 
     private PathBasedResourceResolverImpl getPathBasedResourceResolver() {


### PR DESCRIPTION
Backport of [SLING-12244](https://issues.apache.org/jira/browse/SLING-12244) to the 1.x maintenance branch, tracked as [SLING-13275](https://issues.apache.org/jira/browse/SLING-13275).

Caches the result of `ResourceResolver.getParentResourceType(Resource)` in a per-resolver map keyed by resource path, avoiding repeated repository access for the same resource. The cache is cleared on `refresh()` alongside the existing `resourceTypeLookupCache`.

Cherry-picked from master commit `3abb019`, released in Resource Resolver 2.0.0. It was never backported, so the 1.x line still resolves the parent resource type on every call.

### Note for reviewers

This changes lookup semantics, not just performance: a `sling:resourceSuperType` change is no longer observed by an already-open resolver until `refresh()` is called. That is the same behaviour 2.x has shipped with since 2.0.0.

### Verification

`mvn clean verify` on this branch: BUILD SUCCESS, 645 tests, 0 failures (adds `ResourceResolverImplTest#testGetParentResourceType`, which asserts the second lookup is served from the cache).
