### PR TITLE
SLING-13276: Prevent creating a resource with a name only consisting out of dots (backport to 1.x)

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/ResourceResolverImpl.java
@@ -1024,7 +1024,10 @@ public class ResourceResolverImpl extends SlingAdaptable implements ResourceReso
         }
         // name should be a name not a path
         if (name.indexOf("/") != -1) {
-            throw new IllegalArgumentException("Name should not contain a slash: " + name);
+            throw new IllegalArgumentException("Name must not contain a slash: " + name);
+        }
+        if (name.chars().allMatch(c -> c == '.')) {
+            throw new IllegalArgumentException("Name must not only consist of dots: " + name);
         }
         final String path;
         if (parent.getPath().equals("/")) {

--- a/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverImplTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/ResourceResolverImplTest.java
@@ -519,7 +519,13 @@ public class ResourceResolverImplTest {
             // correct
         }
         try {
-            this.resResolver.create(r, "a", null);
+            this.resResolver.create(r, "....", null);
+            fail("Only dots in name should throw illegal argument exception");
+        } catch (final IllegalArgumentException pe) {
+            // correct
+        }
+        try {
+            this.resResolver.create(r, "a.b", null);
             fail("This should be unsupported.");
         } catch (final UnsupportedOperationException uoe) {
             // correct


### PR DESCRIPTION
Backport of [SLING-12806](https://issues.apache.org/jira/browse/SLING-12806) to the 1.x maintenance branch, tracked as [SLING-13276](https://issues.apache.org/jira/browse/SLING-13276).

Rejects `ResourceResolver.create(...)` calls whose name consists only of dots, since `.` and `..` are path specifiers in `getResource(...)`. This mirrors the existing guard for names containing `/`, whose message is also reworded from "should not" to "must not" for consistency.

Cherry-picked from master commit `5ca4985`, released in Resource Resolver 2.0.0. It was never backported.

### Verification

`mvn clean verify` on this branch: BUILD SUCCESS, 644 tests, 0 failures (extends the existing `create` validation test).
