### PR TITLE
SLING-13277: use java.nio.charset.CharSet to instantiate the String (backport to 1.x)

### DIFF
--- a/src/main/java/org/apache/sling/resourceresolver/impl/helper/URI.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/helper/URI.java
@@ -24,6 +24,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -4007,8 +4008,6 @@ public class URI implements Cloneable, Comparable<URI>, Serializable {
      * headers)
      *
      * @param data the byte array to be encoded
-     * @param offset the index of the first byte to encode
-     * @param length the number of bytes to encode
      * @return The string representation of the byte array
      * @since 3.0
      */
@@ -4018,11 +4017,7 @@ public class URI implements Cloneable, Comparable<URI>, Serializable {
             throw new IllegalArgumentException("Parameter may not be null");
         }
 
-        try {
-            return new String(data, "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            throw new URIException("HttpClient requires ASCII support");
-        }
+        return new String(data, StandardCharsets.US_ASCII);
     }
 
     /**
@@ -4069,11 +4064,7 @@ public class URI implements Cloneable, Comparable<URI>, Serializable {
             throw new IllegalArgumentException("Parameter may not be null");
         }
 
-        try {
-            return data.getBytes("US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            throw new URIException("HttpClient requires ASCII support");
-        }
+        return data.getBytes(StandardCharsets.US_ASCII);
     }
 
     /**


### PR DESCRIPTION
Backport of [SLING-13260](https://issues.apache.org/jira/browse/SLING-13260) to the 1.x maintenance branch, tracked as [SLING-13277](https://issues.apache.org/jira/browse/SLING-13277).

`URI.getAsciiString(...)` and `URI.getAsciiBytes(...)` passed the charset as a `String`, which makes `java.lang.String` perform a `Charset.forName` lookup that synchronizes on `sun.nio.cs.StandardCharsets`. Under load this shows up as threads BLOCKED in `charsetForName`. Passing `StandardCharsets.US_ASCII` directly skips the lookup, and lets the now-unreachable `UnsupportedEncodingException` handling go away.

Cherry-picked from master commit `08e7786`, released in Resource Resolver 2.0.6. It was never backported.

### Verification

`mvn clean verify` on this branch: BUILD SUCCESS, 644 tests, 0 failures.
