### PR TITLE
chore(test): make test_event_alias_during_bg_init deterministic (1.x)

### DIFF
--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/AliasMapEntriesTest.java
@@ -1270,8 +1270,16 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
         Resource leaf1 = createMockedResource(top, "leaf1");
         when(leaf1.getValueMap()).thenReturn(buildValueMap(ResourceResolverImpl.PROP_ALIAS, "alias1"));
 
+        Resource leaf2 = createMockedResource(top, "leaf2");
+        when(leaf2.getValueMap()).thenReturn(buildValueMap(ResourceResolverImpl.PROP_ALIAS, "alias2"));
+
+        // all stubbing must happen before bg init starts - Mockito stubbing is not thread-safe against
+        // concurrent invocations of the same mock
+        removeResource(leaf1);
+
         CountDownLatch greenLight = new CountDownLatch(1);
 
+        // the query still yields the pre-removal snapshot, so the events have to win over it
         when(resourceResolver.findResources(anyString(), eq("JCR-SQL2")))
                 .thenAnswer((Answer<Iterator<Resource>>) invocation -> {
                     greenLight.await();
@@ -1282,12 +1290,7 @@ public class AliasMapEntriesTest extends AbstractMappingMapEntriesTest {
         ah.initializeAliases();
         assertFalse(ah.isReady());
 
-        // bg init will wait until we give green light
-
-        Resource leaf2 = createMockedResource(top, "leaf2");
-        when(leaf2.getValueMap()).thenReturn(buildValueMap(ResourceResolverImpl.PROP_ALIAS, "alias2"));
-
-        removeResource(leaf1);
+        // bg init will wait until we give green light - events only from here on, no stubbing
         mapEntries.onChange(List.of(new ResourceChange(ResourceChange.ChangeType.REMOVED, leaf1.getPath(), false)));
         mapEntries.onChange(List.of(new ResourceChange(ResourceChange.ChangeType.ADDED, leaf2.getPath(), false)));
 


### PR DESCRIPTION
Same change as #222, on `1.x`. This is the flake that has failed both builds of #221, so #221 stays red until this lands.

`AliasMapEntriesTest.test_event_alias_during_bg_init[isOptimizeAliasResolutionEnabled=true,isAliasCacheInitInBackground=true]` keeps stubbing the shared `resourceResolver` mock while the background alias-init thread is parked inside the `findResources` answer. Mockito keeps the invocation being stubbed on the mock's own invocation container rather than per thread, so the stub can bind to `findResources` instead of `getResource` — surfacing either as `WrongTypeOfReturnValue` (PR-221 build #1) or as a silently lost stub that leaves `leaf2` unresolvable (PR-221 build #2, `... should contain an entry for leaf2 ... but got: null`).

The fix moves all mock setup ahead of `initializeAliases()`, so the concurrent window contains only `onChange(...)` calls — matching `VanityPathMapEntriesTest.test_remove_vanity_path_during_bg_init`, which is already written that way. `findResources` still returns the pre-removal snapshot, so the events remain the only route into and out of the alias map.

### Verification

`AliasMapEntriesTest` 30/30 pass on this branch, and `mvn clean verify`: BUILD SUCCESS, 645 tests, 0 failures. On `master` the same change went from 1 failure in 30 baseline runs to 0 in 60.