### PR TITLE
SLING-13287: paging sanity checks - log type when not String

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,8 +169,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIterator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIterator.java
@@ -83,8 +83,8 @@ public class PagedQueryIterator implements Iterator<Resource> {
         page += 1;
     }
 
-    private static String getDiagInformationWhenNotString(ValueMap valueMap, String propertyNName) {
-        Object value = valueMap.get(propertyNName);
+    private static String getDiagInformationWhenNotString(ValueMap valueMap, String propertyName) {
+        Object value = valueMap.get(propertyName);
         if (value == null || value instanceof String[] || value instanceof String) {
             // all good
             return "";

--- a/src/main/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIterator.java
+++ b/src/main/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIterator.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,29 +83,43 @@ public class PagedQueryIterator implements Iterator<Resource> {
         page += 1;
     }
 
+    private static String getDiagInformationWhenNotString(ValueMap valueMap, String propertyNName) {
+        Object value = valueMap.get(propertyNName);
+        if (value == null || value instanceof String[] || value instanceof String) {
+            // all good
+            return "";
+        } else {
+            return " (type: '" + value.getClass() + "')";
+        }
+    }
+
     private Resource getNext() throws NoSuchElementException {
         Resource resource = it.next();
         count += 1;
-        final String[] values = resource.getValueMap().get(propertyName, defaultValue);
+
+        final ValueMap valueMap = resource.getValueMap();
+        final String[] values = valueMap.get(propertyName, defaultValue);
 
         if (values.length > 0) {
             String value = values[0];
             if (value.compareTo(lastKey) < 0) {
                 log.warn(
-                        "unexpected query result in page {}, property name '{}', got '{}', despite querying for > '{}'"
+                        "unexpected query result in page {}, property name '{}', got '{}'{}, despite querying for > '{}'"
                                 + " (the async index may not yet reflect the current property value)",
                         (page - 1),
                         propertyName,
                         value,
+                        getDiagInformationWhenNotString(valueMap, propertyName),
                         lastKey);
             }
             if (lastValue != null && value.compareTo(lastValue) < 0) {
                 log.warn(
-                        "unexpected query result in page {}, property name '{}', got '{}', last value was '{}'"
+                        "unexpected query result in page {}, property name '{}', got '{}'{}, last value was '{}'"
                                 + " (the async index may not yet reflect the current property value)",
                         (page - 1),
                         propertyName,
                         value,
+                        getDiagInformationWhenNotString(valueMap, propertyName),
                         lastValue);
             }
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -111,8 +111,9 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
 
     @Test
     public void testSimpleWrongType() {
-        try (TestLogger logger =
-                TestLogger.createStartedFor(PagedQueryIterator.class).contains("unexpected")) {
+        try (TestLogger logger = TestLogger.create(PagedQueryIterator.class)
+                .contains("unexpected")
+                .start()) {
 
             String[] expected = new String[] {"a", "b", "c"};
             Collection<Resource> expectedResources = toResourceList(expected);
@@ -291,12 +292,12 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
 
         private final Appender<ILoggingEvent> customLogger;
 
-        private final Logger logger;
+        private final Logger delegate;
         private String matchContainsMessage;
         private final List<String> logs = Collections.synchronizedList(new ArrayList<>());
 
         private TestLogger(Class<?> clazz) {
-            this.logger = getLogger(clazz);
+            this.delegate = getLogger(clazz);
 
             this.customLogger = new AppenderBase<>() {
                 @Override
@@ -311,11 +312,17 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
             this.customLogger.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
         }
 
-        public static TestLogger createStartedFor(Class<?> clazz) {
-            TestLogger logger = new TestLogger(clazz);
-            logger.customLogger.start();
-            logger.logger.addAppender(logger.customLogger);
-            return logger;
+        public static TestLogger create(Class<?> clazz) {
+            return new TestLogger(clazz);
+        }
+
+        public TestLogger start() {
+            if (delegate == null) {
+                throw new IllegalStateException();
+            }
+            this.delegate.addAppender(this.customLogger);
+            this.customLogger.start();
+            return this;
         }
 
         public TestLogger contains(String matchContainsMessage) {
@@ -324,13 +331,19 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
         }
 
         public List<String> stopAndGetLogs() {
-            logger.detachAppender(customLogger);
+            if (this.delegate == null) {
+                throw new IllegalStateException();
+            }
+            delegate.detachAppender(customLogger);
             customLogger.stop();
             return logs;
         }
 
         public void close() {
-            logger.detachAppender(customLogger);
+            if (this.delegate == null) {
+                throw new IllegalStateException();
+            }
+            delegate.detachAppender(customLogger);
             customLogger.stop();
             logs.clear();
         }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -24,10 +24,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
 import org.apache.sling.api.resource.QuerySyntaxException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -36,9 +42,11 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -102,27 +110,36 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
 
     @Test
     public void testSimpleWrongType() {
-        // SLING-13284: out-of-order results (from a stale async index) should not abort iteration
-        String[] expected = new String[] {"a", "b", "c"};
-        Collection<Resource> expectedResources = toResourceList(expected);
+        try (TestLogger logger =
+                TestLogger.createStartedFor(PagedQueryIterator.class).contains("unexpected")) {
 
-        Date oneMore = new Date(0);
-        ValueMap properties = new ValueMapDecorator(Map.of(PROPNAME, new Date[] {oneMore}));
-        Resource r = mock(Resource.class);
-        when(r.getValueMap()).thenReturn(properties);
+            String[] expected = new String[] {"a", "b", "c"};
+            Collection<Resource> expectedResources = toResourceList(expected);
 
-        expectedResources.add(r);
+            Date oneMore = new Date(0);
+            ValueMap properties = new ValueMapDecorator(Map.of(PROPNAME, new Date[] {oneMore}));
+            Resource r = mock(Resource.class);
+            when(r.getValueMap()).thenReturn(properties);
 
-        when(resourceResolver.findResources(eq("testSimpleWrongType"), eq("JCR-SQL2")))
-                .thenReturn(expectedResources.iterator());
-        PagedQueryIterator it =
-                new PagedQueryIterator("alias", PROPNAME, resourceResolver, "testSimpleWrongType", 2000);
+            expectedResources.add(r);
 
-        String[] expWithOneMore = Arrays.copyOf(expected, expected.length + 1);
-        // this assumes the way Sling converts Dates to Strings
-        expWithOneMore[expected.length] = oneMore.toInstant().toString();
+            when(resourceResolver.findResources(eq("testSimpleWrongType"), eq("JCR-SQL2")))
+                    .thenReturn(expectedResources.iterator());
+            PagedQueryIterator it =
+                    new PagedQueryIterator("alias", PROPNAME, resourceResolver, "testSimpleWrongType", 2000);
 
-        checkResult(it, expWithOneMore);
+            String[] expWithOneMore = Arrays.copyOf(expected, expected.length + 1);
+            // implementation detail: this assumes the way Sling converts Dates to Strings
+            expWithOneMore[expected.length] = oneMore.toInstant().toString();
+
+            checkResult(it, expWithOneMore);
+
+            // implementation detail: assumes format of log message
+            List<String> logEntries = logger.stopAndGetLogs();
+            assertTrue(
+                    "Log should contain 'class [Ljava.util.Date;', but got: " + logEntries,
+                    logEntries.toString().contains("class [Ljava.util.Date;"));
+        }
     }
 
     @Test
@@ -266,5 +283,59 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
             pos += 1;
         }
         assertFalse(it.hasNext());
+    }
+
+    // inspired by Oak LogCustomizer, to be factored out when needed
+    private static class TestLogger implements AutoCloseable {
+
+        private final Appender<ILoggingEvent> customLogger;
+
+        private final Logger logger;
+        private String matchContainsMessage;
+        private final List<String> logs = Collections.synchronizedList(new ArrayList<>());
+
+        private TestLogger(Class<?> clazz) {
+            this.logger = getLogger(clazz);
+
+            this.customLogger = new AppenderBase<>() {
+                @Override
+                protected void append(ILoggingEvent e) {
+                    String message = e.getFormattedMessage();
+                    if (matchContainsMessage == null || message.contains(matchContainsMessage)) {
+                        logs.add(message);
+                    }
+                }
+            };
+
+            this.customLogger.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        }
+
+        public static TestLogger createStartedFor(Class<?> clazz) {
+            TestLogger logger = new TestLogger(clazz);
+            logger.customLogger.start();
+            logger.logger.addAppender(logger.customLogger);
+            return logger;
+        }
+
+        public TestLogger contains(String matchContainsMessage) {
+            this.matchContainsMessage = matchContainsMessage;
+            return this;
+        }
+
+        public List<String> stopAndGetLogs() {
+            logger.detachAppender(customLogger);
+            customLogger.stop();
+            return logs;
+        }
+
+        public void close() {
+            logger.detachAppender(customLogger);
+            customLogger.stop();
+            logs.clear();
+        }
+
+        private static Logger getLogger(Class<?> clazz) {
+            return ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(clazz);
+        }
     }
 }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -37,6 +38,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -99,13 +101,35 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
     }
 
     @Test
+    public void testSimpleWrongType() {
+        // SLING-13284: out-of-order results (from a stale async index) should not abort iteration
+        String[] expected = new String[] {"a", "b", "c"};
+        Collection<Resource> expectedResources = toResourceList(expected);
+
+        ValueMap m = mock(ValueMap.class);
+        when(m.get(eq(PROPNAME), any(Object.class))).thenReturn(new Date[] {new Date(0)});
+        Resource r = mock(Resource.class);
+        when(r.getValueMap()).thenReturn(m);
+
+        expectedResources.add(r);
+
+        when(resourceResolver.findResources(eq("testSimpleWrongType"), eq("JCR-SQL2")))
+                .thenReturn(expectedResources.iterator());
+        PagedQueryIterator it =
+                new PagedQueryIterator("alias", PROPNAME, resourceResolver, "testSimpleWrongType", 2000);
+        assertNotNull(it);
+        checkResult(it, expected);
+    }
+
+    @Test
     public void testSimpleWrongResultAfterKey() {
         // SLING-13284: out-of-order results across page boundaries should not abort iteration
         String[] expected = new String[] {"x", "x", "a", "a"};
         Collection<Resource> expectedResources = toResourceList(expected);
-        when(resourceResolver.findResources("testSimpleWrongOrder", "JCR-SQL2"))
+        when(resourceResolver.findResources("testSimpleWrongResultAfterKey", "JCR-SQL2"))
                 .thenReturn(expectedResources.iterator());
-        PagedQueryIterator it = new PagedQueryIterator("alias", PROPNAME, resourceResolver, "testSimpleWrongOrder", 1);
+        PagedQueryIterator it =
+                new PagedQueryIterator("alias", PROPNAME, resourceResolver, "testSimpleWrongResultAfterKey", 1);
         int count = 0;
         while (it.hasNext()) {
             it.next();

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -32,13 +32,13 @@ import org.apache.sling.api.resource.QuerySyntaxException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.path.Path;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -106,10 +106,10 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
         String[] expected = new String[] {"a", "b", "c"};
         Collection<Resource> expectedResources = toResourceList(expected);
 
-        ValueMap m = mock(ValueMap.class);
-        when(m.get(eq(PROPNAME), any(Object.class))).thenReturn(new Date[] {new Date(0)});
+        Date oneMore = new Date(0);
+        ValueMap properties = new ValueMapDecorator(Map.of(PROPNAME, new Date[] {oneMore}));
         Resource r = mock(Resource.class);
-        when(r.getValueMap()).thenReturn(m);
+        when(r.getValueMap()).thenReturn(properties);
 
         expectedResources.add(r);
 
@@ -117,8 +117,12 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
                 .thenReturn(expectedResources.iterator());
         PagedQueryIterator it =
                 new PagedQueryIterator("alias", PROPNAME, resourceResolver, "testSimpleWrongType", 2000);
-        assertNotNull(it);
-        checkResult(it, expected);
+
+        String[] expWithOneMore = Arrays.copyOf(expected, expected.length + 1);
+        // this assumes the way Sling converts Dates to Strings
+        expWithOneMore[expected.length] = oneMore.toInstant().toString();
+
+        checkResult(it, expWithOneMore);
     }
 
     @Test

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -39,6 +39,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.path.Path;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.api.wrappers.impl.ObjectConverter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
@@ -130,7 +131,7 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
 
             String[] expWithOneMore = Arrays.copyOf(expected, expected.length + 1);
             // implementation detail: this assumes the way Sling converts Dates to Strings
-            expWithOneMore[expected.length] = oneMore.toInstant().toString();
+            expWithOneMore[expected.length] = ObjectConverter.convert(oneMore, String.class);
 
             checkResult(it, expWithOneMore);
 

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/PagedQueryIteratorTest.java
@@ -29,11 +29,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
-import ch.qos.logback.core.AppenderBase;
 import org.apache.sling.api.resource.QuerySyntaxException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
@@ -43,7 +38,6 @@ import org.apache.sling.api.wrappers.impl.ObjectConverter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -285,71 +279,5 @@ public class PagedQueryIteratorTest extends AbstractMappingMapEntriesTest {
             pos += 1;
         }
         assertFalse(it.hasNext());
-    }
-
-    // inspired by Oak LogCustomizer, to be factored out when needed
-    private static class TestLogger implements AutoCloseable {
-
-        private final Appender<ILoggingEvent> customLogger;
-
-        private final Logger delegate;
-        private String matchContainsMessage;
-        private final List<String> logs = Collections.synchronizedList(new ArrayList<>());
-
-        private TestLogger(Class<?> clazz) {
-            this.delegate = getLogger(clazz);
-
-            this.customLogger = new AppenderBase<>() {
-                @Override
-                protected void append(ILoggingEvent e) {
-                    String message = e.getFormattedMessage();
-                    if (matchContainsMessage == null || message.contains(matchContainsMessage)) {
-                        logs.add(message);
-                    }
-                }
-            };
-
-            this.customLogger.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
-        }
-
-        public static TestLogger create(Class<?> clazz) {
-            return new TestLogger(clazz);
-        }
-
-        public TestLogger start() {
-            if (delegate == null) {
-                throw new IllegalStateException();
-            }
-            this.delegate.addAppender(this.customLogger);
-            this.customLogger.start();
-            return this;
-        }
-
-        public TestLogger contains(String matchContainsMessage) {
-            this.matchContainsMessage = matchContainsMessage;
-            return this;
-        }
-
-        public List<String> stopAndGetLogs() {
-            if (this.delegate == null) {
-                throw new IllegalStateException();
-            }
-            delegate.detachAppender(customLogger);
-            customLogger.stop();
-            return logs;
-        }
-
-        public void close() {
-            if (this.delegate == null) {
-                throw new IllegalStateException();
-            }
-            delegate.detachAppender(customLogger);
-            customLogger.stop();
-            logs.clear();
-        }
-
-        private static Logger getLogger(Class<?> clazz) {
-            return ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(clazz);
-        }
     }
 }

--- a/src/test/java/org/apache/sling/resourceresolver/impl/mapping/TestLogger.java
+++ b/src/test/java/org/apache/sling/resourceresolver/impl/mapping/TestLogger.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.resourceresolver.impl.mapping;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import org.slf4j.LoggerFactory;
+
+// inspired by Oak's LogCustomizer
+public class TestLogger implements AutoCloseable {
+    private final Appender<ILoggingEvent> customLogger;
+
+    private final Logger delegate;
+    private String matchContainsMessage;
+    private final List<String> logs = Collections.synchronizedList(new ArrayList<>());
+
+    private TestLogger(Class<?> clazz) {
+        this.delegate = getLogger(clazz);
+
+        this.customLogger = new AppenderBase<>() {
+            @Override
+            protected void append(ILoggingEvent e) {
+                String message = e.getFormattedMessage();
+                if (matchContainsMessage == null || message.contains(matchContainsMessage)) {
+                    logs.add(message);
+                }
+            }
+        };
+
+        this.customLogger.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    }
+
+    public static TestLogger create(Class<?> clazz) {
+        return new TestLogger(clazz);
+    }
+
+    public TestLogger start() {
+        if (delegate == null) {
+            throw new IllegalStateException();
+        }
+        this.delegate.addAppender(this.customLogger);
+        this.customLogger.start();
+        return this;
+    }
+
+    public TestLogger contains(String matchContainsMessage) {
+        this.matchContainsMessage = matchContainsMessage;
+        return this;
+    }
+
+    public List<String> stopAndGetLogs() {
+        if (this.delegate == null) {
+            throw new IllegalStateException();
+        }
+        delegate.detachAppender(customLogger);
+        customLogger.stop();
+        return logs;
+    }
+
+    public void close() {
+        if (this.delegate == null) {
+            throw new IllegalStateException();
+        }
+        delegate.detachAppender(customLogger);
+        customLogger.stop();
+        logs.clear();
+    }
+
+    private static Logger getLogger(Class<?> clazz) {
+        return ((LoggerContext) LoggerFactory.getILoggerFactory()).getLogger(clazz);
+    }
+}


### PR DESCRIPTION
Note that the test does not verify the log output (which makes it kind of lame). Do we have a simple way to do this, such as LogCustomizer in Oak?